### PR TITLE
Add a `saveAs` option to prompt a dialog instead of downloading immediately

### DIFF
--- a/index.js
+++ b/index.js
@@ -50,7 +50,7 @@ module.exports = () => {
 };
 
 module.exports.download = (win, url, opts = {}) => {
-	opts.unregisterWhenDone = true;
+	opts = Object.assign({}, opts, {unregisterWhenDone: true});
 	registerListener(win, opts);
 	win.webContents.downloadURL(url);
 };

--- a/index.js
+++ b/index.js
@@ -8,7 +8,9 @@ function registerListener(win, opts = {}) {
 		const totalBytes = item.getTotalBytes();
 		const filePath = path.join(app.getPath('downloads'), item.getFilename());
 
-		item.setSavePath(filePath);
+		if (!opts.saveAs) {
+			item.setSavePath(filePath);
+		}
 
 		// TODO: use mime type checking for file extension when no extension can be inferred
 		// item.getMimeType()
@@ -47,7 +49,8 @@ module.exports = () => {
 	});
 };
 
-module.exports.download = (win, url) => {
-	registerListener(win, {unregisterWhenDone: true});
+module.exports.download = (win, url, opts = {}) => {
+	opts.unregisterWhenDone = true;
+	registerListener(win, opts);
 	win.webContents.downloadURL(url);
 };

--- a/readme.md
+++ b/readme.md
@@ -51,6 +51,33 @@ ipcMain.on('download-btn', (e, args) => {
 });
 ```
 
+## API
+
+### download(window, url, [options])
+
+### window
+
+Type: `BrowserWindow`
+
+Window to register the behaviour on
+
+### url
+
+Type: `String`
+
+The URL to download
+
+### options
+
+#### saveAs
+
+Type: `Boolean`
+
+Default: `false`
+
+Show a "Save As…" dialog instead of downloading immediately.
+
+Useful if you're concerned about overriding existing files. See [issue #3](https://github.com/sindresorhus/electron-dl/issues/3)
 
 ## Related
 

--- a/readme.md
+++ b/readme.md
@@ -59,25 +59,23 @@ ipcMain.on('download-btn', (e, args) => {
 
 Type: `BrowserWindow`
 
-Window to register the behaviour on
+Window to register the behaviour on.
 
 ### url
 
-Type: `String`
+Type: `string`
 
-The URL to download
+URL to download.
 
 ### options
 
 #### saveAs
 
-Type: `Boolean`
+Type: `boolean`
 
 Default: `false`
 
 Show a "Save As…" dialog instead of downloading immediately.
-
-Useful if you're concerned about overriding existing files. See [issue #3](https://github.com/sindresorhus/electron-dl/issues/3)
 
 ## Related
 


### PR DESCRIPTION
Added to allow working around #3, and also nice to have the option.