### PR TITLE
Make download() return a Promise

### DIFF
--- a/index.js
+++ b/index.js
@@ -27,9 +27,10 @@ function registerListener(win, opts = {}, cb) {
 			}
 
 			if (state === 'interrupted') {
-				electron.dialog.showErrorBox('Download error', `The download of ${item.getFilename()} was interrupted`);
+				const message = `The download of ${item.getFilename()} was interrupted`;
+				electron.dialog.showErrorBox('Download error', message);
 				if (cb) {
-					cb(new Error(`The download of ${item.getFilename()} was interrupted`));
+					cb(new Error(message));
 				}
 			}
 

--- a/readme.md
+++ b/readme.md
@@ -49,7 +49,7 @@ const {download} = require('electron-dl');
 ipcMain.on('download-btn', (e, args) => {
 	download(BrowserWindow.getFocusedWindow(), args.url)
 		.then(dl => console.log(dl.getSavePath()))
-		.catch(err => console.error(err));
+		.catch(console.error);
 });
 ```
 

--- a/readme.md
+++ b/readme.md
@@ -47,13 +47,15 @@ const {app, BrowserWindow, ipcMain} = require('electron');
 const {download} = require('electron-dl');
 
 ipcMain.on('download-btn', (e, args) => {
-	download(BrowserWindow.getFocusedWindow(), args.url);
+	download(BrowserWindow.getFocusedWindow(), args.url)
+		.then(dl => console.log(dl.getSavePath()))
+		.catch(err => console.error(err));
 });
 ```
 
 ## API
 
-### download(window, url, [options])
+### download(window, url, [options]): Promise<[DownloadItem](https://github.com/electron/electron/blob/master/docs/api/download-item.md)>
 
 ### window
 


### PR DESCRIPTION
Hi there!

I have a use case for programmatically triggering downloads and then processing each downloaded file in-place.

With that in mind, this is what I came up with. `download()` now returns a `Promise` that resolves with the completed `DownloadItem`.