### PR TITLE
New options for localization and callbacks

### DIFF
--- a/index.js
+++ b/index.js
@@ -21,7 +21,7 @@ function registerListener(win, opts = {}, cb = () => {}) {
 		// item.getMimeType()
 
 		item.on('updated', () => {
-			let ratio = item.getReceivedBytes() / totalBytes
+			const ratio = item.getReceivedBytes() / totalBytes
 			win.setProgressBar(ratio);
 			if(opts.onProgress && typeof opts.onProgress === "function"){
 				opts.onProgress(ratio)
@@ -34,7 +34,8 @@ function registerListener(win, opts = {}, cb = () => {}) {
 			}
 
 			if (state === 'interrupted') {
-				electron.dialog.showErrorBox(errorTitle, errorMessage.replace('FILENAME',item.getFilename()));
+				const message = errorMessage.replace('FILENAME',item.getFilename())
+				electron.dialog.showErrorBox(errorTitle, message);
 				cb(new Error(message));
 			} else if (state === 'completed') {
 

--- a/index.js
+++ b/index.js
@@ -2,6 +2,7 @@
 const path = require('path');
 const electron = require('electron');
 const unusedFilename = require('unused-filename');
+const pupa = require('pupa');
 
 const app = electron.app;
 
@@ -10,7 +11,7 @@ function registerListener(win, opts = {}, cb = () => {}) {
 		const totalBytes = item.getTotalBytes();
 		const dir = opts.directory || app.getPath('downloads');
 		const filePath = unusedFilename.sync(path.join(dir, item.getFilename()));
-		const errorMessage = opts.errorMessage || 'The download of FILENAME was interrupted';
+		const errorMessage = opts.errorMessage || 'The download of {filename} was interrupted';
 		const errorTitle = opts.errorTitle || 'Download Error';
 
 		if (!opts.saveAs) {
@@ -34,14 +35,10 @@ function registerListener(win, opts = {}, cb = () => {}) {
 			}
 
 			if (state === 'interrupted') {
-				const message = errorMessage.replace('FILENAME', item.getFilename());
+				const message = pupa(errorMessage,{filename:item.getFilename()})
 				electron.dialog.showErrorBox(errorTitle, message);
 				cb(new Error(message));
 			} else if (state === 'completed') {
-				if (opts.onComplete && typeof opts.onComplete === 'function') {
-					opts.onComplete(filePath);
-				}
-
 				if (process.platform === 'darwin') {
 					app.dock.downloadFinished(filePath);
 				}

--- a/index.js
+++ b/index.js
@@ -24,7 +24,8 @@ function registerListener(win, opts = {}, cb = () => {}) {
 		item.on('updated', () => {
 			const ratio = item.getReceivedBytes() / totalBytes;
 			win.setProgressBar(ratio);
-			if (opts.onProgress && typeof opts.onProgress === 'function') {
+			
+			if (typeof opts.onProgress === 'function') {
 				opts.onProgress(ratio);
 			}
 		});

--- a/index.js
+++ b/index.js
@@ -10,8 +10,8 @@ function registerListener(win, opts = {}, cb = () => {}) {
 		const totalBytes = item.getTotalBytes();
 		const dir = opts.directory || app.getPath('downloads');
 		const filePath = unusedFilename.sync(path.join(dir, item.getFilename()));
-		const errorMessage = 'The download of FILENAME was interrupted' || opts.errorMessage;
-		const errorTitle = 'Download Error' || opts.errorTitle;
+		const errorMessage = opts.errorMessage || 'The download of FILENAME was interrupted';
+		const errorTitle = opts.errorTitle || 'Download Error';
 
 		if (!opts.saveAs) {
 			item.setSavePath(filePath);

--- a/index.js
+++ b/index.js
@@ -21,9 +21,9 @@ function registerListener(win, opts = {}, cb = () => {}) {
 		// item.getMimeType()
 
 		item.on('updated', () => {
-			const ratio = item.getReceivedBytes() / totalBytes
+			const ratio = item.getReceivedBytes() / totalBytes;
 			win.setProgressBar(ratio);
-			if(opts.onProgress && typeof opts.onProgress === "function"){
+			if (opts.onProgress && typeof opts.onProgress === 'function') {
 				opts.onProgress(ratio)
 			}
 		});
@@ -34,13 +34,12 @@ function registerListener(win, opts = {}, cb = () => {}) {
 			}
 
 			if (state === 'interrupted') {
-				const message = errorMessage.replace('FILENAME',item.getFilename())
+				const message = errorMessage.replace('FILENAME', item.getFilename());
 				electron.dialog.showErrorBox(errorTitle, message);
 				cb(new Error(message));
 			} else if (state === 'completed') {
-
-				if(opts.onComplete && typeof opts.onComplete === "function"){
-					opts.onComplete(filePath)
+				if (opts.onComplete && typeof opts.onComplete === 'function') {
+					opts.onComplete(filePath);
 				}
 
 				if (process.platform === 'darwin') {

--- a/index.js
+++ b/index.js
@@ -35,7 +35,7 @@ function registerListener(win, opts = {}, cb = () => {}) {
 			}
 
 			if (state === 'interrupted') {
-				const message = pupa(errorMessage,{filename:item.getFilename()});
+				const message = pupa(errorMessage, {filename: item.getFilename()});
 				electron.dialog.showErrorBox(errorTitle, message);
 				cb(new Error(message));
 			} else if (state === 'completed') {

--- a/index.js
+++ b/index.js
@@ -24,7 +24,7 @@ function registerListener(win, opts = {}, cb = () => {}) {
 			const ratio = item.getReceivedBytes() / totalBytes;
 			win.setProgressBar(ratio);
 			if (opts.onProgress && typeof opts.onProgress === 'function') {
-				opts.onProgress(ratio)
+				opts.onProgress(ratio);
 			}
 		});
 

--- a/index.js
+++ b/index.js
@@ -35,7 +35,7 @@ function registerListener(win, opts = {}, cb = () => {}) {
 			}
 
 			if (state === 'interrupted') {
-				const message = pupa(errorMessage,{filename:item.getFilename()})
+				const message = pupa(errorMessage,{filename:item.getFilename()});
 				electron.dialog.showErrorBox(errorTitle, message);
 				cb(new Error(message));
 			} else if (state === 'completed') {

--- a/package.json
+++ b/package.json
@@ -25,6 +25,7 @@
     "progress"
   ],
   "dependencies": {
+    "pupa": "^1.0.0",
     "unused-filename": "^0.1.0"
   },
   "devDependencies": {

--- a/readme.md
+++ b/readme.md
@@ -99,24 +99,16 @@ The title of the error dialog. Can be customised for localization.
 #### errorMessage
 
 Type: `string`<br>
-Default: `The download of FILENAME was interrupted`
+Default: `The download of {filename} was interrupted`
 
-The message of the error dialog. `FILENAME` is replaced with the name of the actual file. Can be customised for localization.
+The message of the error dialog. `{filename}` is replaced with the name of the actual file. Can be customised for localization.
 
 #### onProgress
 
-Type: `function`<br>
+Type: `Function`<br>
 Default: `undefined`
 
 An optional callback to receive a ratio between `0` and `1` with the state of the current download.
-
-#### onComplete
-
-Type: `function`<br>
-Default: `undefined`
-
-An optional callback that will be called when the download finishes. It returns the complete path of the downloaded file.
-
 
 ## Related
 

--- a/readme.md
+++ b/readme.md
@@ -89,6 +89,34 @@ Default: [User's downloads directory](http://electron.atom.io/docs/api/app/#appg
 
 Directory to save the file in.
 
+#### errorTitle
+
+Type: `string`<br>
+Default: `Download Error`
+
+The title of the error dialog. Can be customised for localization.
+
+#### errorMessage
+
+Type: `string`<br>
+Default: `The download of FILENAME was interrupted`
+
+The message of the error dialog. `FILENAME` is replaced with the name of the actual file. Can be customised for localization.
+
+#### onProgress
+
+Type: `function`<br>
+Default: `undefined`
+
+An optional callback to receive a ratio between `0` and `1` with the state of the current download.
+
+#### onComplete
+
+Type: `function`<br>
+Default: `undefined`
+
+An optional callback that will be called when the download finishes. It returns the complete path of the downloaded file.
+
 
 ## Related
 

--- a/readme.md
+++ b/readme.md
@@ -94,21 +94,21 @@ Directory to save the file in.
 Type: `string`<br>
 Default: `Download Error`
 
-The title of the error dialog. Can be customised for localization.
+Title of the error dialog. Can be customized for localization.
 
 #### errorMessage
 
 Type: `string`<br>
 Default: `The download of {filename} was interrupted`
 
-The message of the error dialog. `{filename}` is replaced with the name of the actual file. Can be customised for localization.
+Message of the error dialog. `{filename}` is replaced with the name of the actual file. Can be customized for localization.
 
 #### onProgress
 
-Type: `Function`<br>
-Default: `undefined`
+Type: `Function`
 
-An optional callback to receive a ratio between `0` and `1` with the state of the current download.
+Optional callback that receives a number between `0` and `1` representing the progress of the current download.
+
 
 ## Related
 


### PR DESCRIPTION
I've added 4 new options for the config object.

- `onProgress` a callback to receive the download progress ratio
- `onComplete` a callback to let know the user when the download has finished
- `errorTitle` the title of the error dialog
- `errorMessage` the message of the error dialog

For `errorMessage` there is no way of passing a template literal (since it's interpreted when the string is created) so I had to use `string.replace(...)`.

