### PR TITLE
New option to open containing folder after finished download

### DIFF
--- a/index.js
+++ b/index.js
@@ -36,6 +36,7 @@ function registerListener(win, opts = {}, cb = () => {}) {
 				if (process.platform === 'darwin') {
 					app.dock.downloadFinished(filePath);
 				} else {
+					// After successful download, open the containing folder
 					shell.showItemInFolder(filePath);
 				}
 

--- a/index.js
+++ b/index.js
@@ -4,6 +4,7 @@ const electron = require('electron');
 const unusedFilename = require('unused-filename');
 
 const app = electron.app;
+const shell = electron.shell;
 
 function registerListener(win, opts = {}, cb = () => {}) {
 	const listener = (e, item, webContents) => {
@@ -34,6 +35,8 @@ function registerListener(win, opts = {}, cb = () => {}) {
 			} else if (state === 'completed') {
 				if (process.platform === 'darwin') {
 					app.dock.downloadFinished(filePath);
+				} else {
+					shell.showItemInFolder(filePath);
 				}
 
 				if (opts.unregisterWhenDone) {

--- a/index.js
+++ b/index.js
@@ -35,8 +35,9 @@ function registerListener(win, opts = {}, cb = () => {}) {
 			} else if (state === 'completed') {
 				if (process.platform === 'darwin') {
 					app.dock.downloadFinished(filePath);
-				} else {
-					// After successful download, open the containing folder
+				}
+
+				if (opts.openFolderWhenDone) {
 					shell.showItemInFolder(filePath);
 				}
 


### PR DESCRIPTION
I've added a new option `openFolderWhenDone` to open the containing folder automatically after the download finished. 

When #11 gets accepted, this behavior could be also achieved via subscribing to the `onComplete` callback.  