### PR TITLE
Prevent “Object destroyed” error after closing a window

### DIFF
--- a/index.js
+++ b/index.js
@@ -24,7 +24,9 @@ function registerListener(win, opts = {}, cb = () => {}) {
 
 		item.on('updated', () => {
 			const ratio = item.getReceivedBytes() / totalBytes;
-			win.setProgressBar(ratio);
+			if (!win.isDestroyed()) {
+				win.setProgressBar(ratio);
+			}
 
 			if (typeof opts.onProgress === 'function') {
 				opts.onProgress(ratio);


### PR DESCRIPTION
Hello @sindresorhus!   Thank you for an awesome module!

I have an electron app with multiple windows and I've found that when I configure it following the readme like this:

```
require('electron-dl')();
```

If I close a window and then download a file in a separate window I receive the following error:

<img width="428" alt="screen shot 2017-03-30 at 7 50 46 pm" src="https://cloud.githubusercontent.com/assets/70799/24534435/dad59f0c-1582-11e7-8285-52f748f22883.png">

I believe this is because `win.setProgressBar(ratio);` is being called on the destroyed window.  I've added the same check you placed in the 'done' event handler to fix it.

If you think there is a better way to handle this without updating the library I'm all ears!

Thank you,
Nick