### PR TITLE
Add `showBadge` option

### DIFF
--- a/index.js
+++ b/index.js
@@ -60,7 +60,7 @@ function registerListener(session, opts = {}, cb = () => {}) {
 				return receivedBytes;
 			}, completedBytes);
 
-			if (['darwin', 'linux'].includes(process.platform)) {
+			if (!opts.hideBadge && ['darwin', 'linux'].includes(process.platform)) {
 				app.setBadgeCount(activeDownloadItems());
 			}
 
@@ -77,7 +77,7 @@ function registerListener(session, opts = {}, cb = () => {}) {
 			completedBytes += item.getTotalBytes();
 			downloadItems.delete(item);
 
-			if (!opts.hideBadge && ['darwin', 'linux'].includes(process.platform)) {
+			if (['darwin', 'linux'].includes(process.platform)) {
 				app.setBadgeCount(activeDownloadItems());
 			}
 

--- a/index.js
+++ b/index.js
@@ -77,7 +77,7 @@ function registerListener(session, opts = {}, cb = () => {}) {
 			completedBytes += item.getTotalBytes();
 			downloadItems.delete(item);
 
-			if (['darwin', 'linux'].includes(process.platform)) {
+			if (!opts.hideBadge && ['darwin', 'linux'].includes(process.platform)) {
 				app.setBadgeCount(activeDownloadItems());
 			}
 

--- a/readme.md
+++ b/readme.md
@@ -128,6 +128,13 @@ Default: `false`
 
 Reveal the downloaded file in the system file manager, and if possible, select the file.
 
+#### hideBadge
+
+Type: `boolean`<br>
+Default: `false`
+
+Hides the file count badge on macOS/Linux dock icons.
+
 
 ## Development
 


### PR DESCRIPTION
Optional download badges because badge can conflict with other notifications that an app might have.