### PR TITLE
Fix problem where folder would not open if one replaces an existing file

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 node_modules
 yarn.lock
+.idea

--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,2 @@
 node_modules
 yarn.lock
-.idea

--- a/index.js
+++ b/index.js
@@ -98,7 +98,7 @@ function registerListener(session, opts = {}, cb = () => {}) {
 				}
 
 				if (opts.openFolderWhenDone) {
-					shell.showItemInFolder(filePath);
+					shell.showItemInFolder(path.join(dir, item.getFilename()));
 				}
 
 				if (opts.unregisterWhenDone) {


### PR DESCRIPTION
If one choose to use saveAs behaviour and the user downloads a file for the second time, the code for opening that file after the download has completed does not work. This fix will always use name of the actual file that was downloaded, not some initial variable set up front.