### PR TITLE
Add `showBadge` option

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 node_modules
 yarn.lock
+.idea

--- a/index.js
+++ b/index.js
@@ -60,7 +60,7 @@ function registerListener(session, opts = {}, cb = () => {}) {
 				return receivedBytes;
 			}, completedBytes);
 
-			if (['darwin', 'linux'].includes(process.platform)) {
+			if (opts.showBadge !== false && ['darwin', 'linux'].includes(process.platform)) {
 				app.setBadgeCount(activeDownloadItems());
 			}
 
@@ -77,7 +77,7 @@ function registerListener(session, opts = {}, cb = () => {}) {
 			completedBytes += item.getTotalBytes();
 			downloadItems.delete(item);
 
-			if (['darwin', 'linux'].includes(process.platform)) {
+			if (opts.showBadge !== false && ['darwin', 'linux'].includes(process.platform)) {
 				app.setBadgeCount(activeDownloadItems());
 			}
 

--- a/readme.md
+++ b/readme.md
@@ -128,6 +128,12 @@ Default: `false`
 
 Reveal the downloaded file in the system file manager, and if possible, select the file.
 
+#### showBadge
+
+Type: `boolean`<br>
+Default: `true`
+
+Shows the file count badge on macOS/Linux dock icons when download is in progress.
 
 ## Development
 


### PR DESCRIPTION
A new option ```showBadge``` has been added. It defaults to true. If it is false, no badge count will be shown on dock icon for macOS and Linux while downloads are active.

Closes #40 
Fixes #39 