### PR TITLE
Exposed download item to allow canceling

### DIFF
--- a/index.js
+++ b/index.js
@@ -96,6 +96,10 @@ function registerListener(session, options, cb = () => {}) {
 				totalBytes = 0;
 			}
 
+			if (options.unregisterWhenDone) {
+				session.removeListener('will-download', listener);
+			}
+
 			if (state === 'interrupted') {
 				const message = pupa(errorMessage, {filename: item.getFilename()});
 				electron.dialog.showErrorBox(errorTitle, message);
@@ -107,10 +111,6 @@ function registerListener(session, options, cb = () => {}) {
 
 				if (options.openFolderWhenDone) {
 					shell.showItemInFolder(path.join(dir, item.getFilename()));
-				}
-
-				if (options.unregisterWhenDone) {
-					session.removeListener('will-download', listener);
 				}
 
 				cb(null, item);

--- a/index.js
+++ b/index.js
@@ -58,6 +58,10 @@ function registerListener(session, options, cb = () => {}) {
 			item.setSavePath(filePath);
 		}
 
+		if (typeof options.onStarted === 'function') {
+			options.onStarted(item);
+		}
+
 		item.on('updated', () => {
 			receivedBytes = [...downloadItems].reduce((receivedBytes, item) => {
 				receivedBytes += item.getReceivedBytes();

--- a/readme.md
+++ b/readme.md
@@ -115,6 +115,13 @@ Default: `The download of {filename} was interrupted`
 
 Message of the error dialog. `{filename}` is replaced with the name of the actual file. Can be customized for localization.
 
+#### onStarted
+
+Type: `Function`
+
+Optional callback that receives the [download item](https://electronjs.org/docs/api/download-item).
+You can use this for advanced handling such as canceling the item like `item.cancel()`.
+
 #### onProgress
 
 Type: `Function`


### PR DESCRIPTION
This fixes #10 and is related to #25.

This adds a callback `onStarted` that gives the download item. This is a non-intrusive enhancement that enables developers to handle advanced situations such as canceling a download.

This also updates removing the listener when the item is done. Before it would only be removed if `completed`. Now the listener will be removed when canceled or interrupted as well.