### PR TITLE
Optional callback for cancelled state of download

### DIFF
--- a/index.js
+++ b/index.js
@@ -95,7 +95,7 @@ function registerListener(session, options, cb = () => {}) {
 				completedBytes = 0;
 				totalBytes = 0;
 			}
-      
+
 			if (options.unregisterWhenDone) {
 				session.removeListener('will-download', listener);
 			}

--- a/index.js
+++ b/index.js
@@ -92,7 +92,11 @@ function registerListener(session, options, cb = () => {}) {
 				totalBytes = 0;
 			}
 
-			if (state === 'interrupted') {
+			if (state === 'cancelled') {
+				if (typeof options.onCancel === 'function') {
+					options.onCancel(item);
+				}
+			} else if (state === 'interrupted') {
 				const message = pupa(errorMessage, {filename: item.getFilename()});
 				electron.dialog.showErrorBox(errorTitle, message);
 				cb(new Error(message));

--- a/index.js
+++ b/index.js
@@ -96,7 +96,7 @@ function registerListener(session, options, cb = () => {}) {
 				totalBytes = 0;
 			}
       
-      if (options.unregisterWhenDone) {
+			if (options.unregisterWhenDone) {
 				session.removeListener('will-download', listener);
 			}
 

--- a/readme.md
+++ b/readme.md
@@ -125,7 +125,7 @@ Optional callback that receives a number between `0` and `1` representing the pr
 
 Type: `Function`
 
-Optional callback that receives on downloadItem for which the download has been cancelled.
+Optional callback that receives the downloadItem for which the download has been cancelled.
 
 #### openFolderWhenDone
 

--- a/readme.md
+++ b/readme.md
@@ -121,6 +121,12 @@ Type: `Function`
 
 Optional callback that receives a number between `0` and `1` representing the progress of the current download.
 
+#### onCancel
+
+Type: `Function`
+
+Optional callback that receives on downloadItem for which the download has been cancelled.
+
 #### openFolderWhenDone
 
 Type: `boolean`<br>


### PR DESCRIPTION
It will be useful to have a callback in-case user cancels the download in saveAs option...
eg. useful for managing download spinner on download button.