### PR TITLE
Add TypeScript definition

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -1,6 +1,7 @@
 export interface Options {
 	/**
 	 * Show a `Save As…` dialog instead of downloading immediately.
+	 *
 	 * Note: Only use this option when strictly necessary. Downloading directly without a prompt is a much better user experience.
 	 *
 	 * @default false
@@ -48,7 +49,7 @@ export interface Options {
 	onProgress?: (percent: number) => void;
 
 	/**
-	 * Optional callback that receives the downloadItem for which the download has been cancelled.
+	 * Optional callback that receives the [download item](https://electronjs.org/docs/api/download-item) for which the download has been cancelled.
 	 */
 	onCancel?: (item: Electron.DownloadItem) => void;
 
@@ -70,16 +71,14 @@ export interface Options {
 /**
  * Register the helper for all windows.
  *
- * @param options
- *
  * @example
  *
- * const {app, BrowserWindow} = require('electron');
+ * import {app, BrowserWindow} from 'electron';
+ * import electronDl from 'electron-dl';
  *
- * require('electron-dl')();
+ * electronDl();
  *
  * let win;
- *
  * app.on('ready', () => {
  * 	win = new BrowserWindow();
  * });
@@ -92,18 +91,18 @@ export default function electronDl(options?: Options): void;
  * @param window - Window to register the behavior on.
  * @param url - URL to download.
  * @param options
- * @returns A promise containing downloaded file
+ * @returns A promise for the downloaded file.
  *
  * @example
  *
- * const {app, BrowserWindow, ipcMain} = require('electron');
- * const {download} = require('electron-dl');
+ * import {BrowserWindow, ipcMain} from 'electron';
+ * import {download} from 'electron-dl';
  *
- * ipcMain.on('download-btn', (e, args) => {
- * 	download(BrowserWindow.getFocusedWindow(), args.url)
- * 	.then(dl => console.log(dl.getSavePath()))
- * 	.catch(console.error);
+ * ipcMain.on('download-button', async (event, {url}) => {
+ * 	const win = BrowserWindow.getFocusedWindow();
+ * 	console.log(await download(win, url));
  * });
+ *
  */
 export function download(
 	window: Electron.BrowserWindow,

--- a/index.d.ts
+++ b/index.d.ts
@@ -1,0 +1,112 @@
+export interface Options {
+	/**
+	 * Show a `Save As…` dialog instead of downloading immediately.
+	 * Note: Only use this option when strictly necessary. Downloading directly without a prompt is a much better user experience.
+	 *
+	 * @default false
+	 */
+	saveAs?: boolean;
+
+	/**
+	 * Directory to save the file in.
+	 *
+	 * Default: [User's downloads directory](https://electronjs.org/docs/api/app/#appgetpathname)
+	 */
+	directory?: string;
+
+	/**
+	 * Name of the saved file.
+	 * This option only makes sense for `electronDl.download()`.
+	 *
+	 * Default: [`downloadItem.getFilename()`](https://electronjs.org/docs/api/download-item/#downloaditemgetfilename)
+	 */
+	filename?: string;
+
+	/**
+	 * Title of the error dialog. Can be customized for localization.
+	 *
+	 * @default 'Download Error'
+	 */
+	errorTitle?: string;
+
+	/**
+	 * Message of the error dialog. `{filename}` is replaced with the name of the actual file. Can be customized for localization.
+	 *
+	 * @default 'The download of {filename} was interrupted'
+	 */
+	errorMessage?: string;
+
+	/**
+	 * Optional callback that receives the [download item](https://electronjs.org/docs/api/download-item).
+	 * You can use this for advanced handling such as canceling the item like `item.cancel()`.
+	 */
+	onStarted?: (item: Electron.DownloadItem) => void;
+
+	/**
+	 * Optional callback that receives a number between `0` and `1` representing the progress of the current download.
+	 */
+	onProgress?: (percent: number) => void;
+
+	/**
+	 * Optional callback that receives the downloadItem for which the download has been cancelled.
+	 */
+	onCancel?: (item: Electron.DownloadItem) => void;
+
+	/**
+	 * Reveal the downloaded file in the system file manager, and if possible, select the file.
+	 *
+	 * @default false
+	 */
+	openFolderWhenDone?: boolean;
+
+	/**
+	 * Shows the file count badge on macOS/Linux dock icons when download is in progress.
+	 *
+	 * @default true
+	 */
+	showBadge?: boolean;
+}
+
+/**
+ * Register the helper for all windows.
+ *
+ * @param options
+ *
+ * @example
+ *
+ * const {app, BrowserWindow} = require('electron');
+ *
+ * require('electron-dl')();
+ *
+ * let win;
+ *
+ * app.on('ready', () => {
+ * 	win = new BrowserWindow();
+ * });
+ */
+export default function electronDl(options?: Options): void;
+
+/**
+ * This can be useful if you need download functionality in a reusable module.
+ *
+ * @param window - Window to register the behavior on.
+ * @param url - URL to download.
+ * @param options
+ * @returns A promise containing downloaded file
+ *
+ * @example
+ *
+ * const {app, BrowserWindow, ipcMain} = require('electron');
+ * const {download} = require('electron-dl');
+ *
+ * ipcMain.on('download-btn', (e, args) => {
+ * 	download(BrowserWindow.getFocusedWindow(), args.url)
+ * 	.then(dl => console.log(dl.getSavePath()))
+ * 	.catch(console.error);
+ * });
+ */
+export function download(
+	window: Electron.BrowserWindow,
+	url: string,
+	options?: Options
+): Promise<Electron.DownloadItem>;

--- a/index.js
+++ b/index.js
@@ -130,6 +130,8 @@ module.exports = (options = {}) => {
 	});
 };
 
+module.exports.default = module.exports;
+
 module.exports.download = (win, url, options) => new Promise((resolve, reject) => {
 	options = Object.assign({}, options, {unregisterWhenDone: true});
 

--- a/index.test-d.ts
+++ b/index.test-d.ts
@@ -1,0 +1,7 @@
+import {expectType} from 'tsd-check';
+import {BrowserWindow} from 'electron';
+import electronDl from '.';
+import {download} from '.';
+
+expectType<void>(electronDl());
+expectType<Electron.DownloadItem>(await download(new BrowserWindow(), 'test', {errorTitle: 'Nope'}));

--- a/index.test-d.ts
+++ b/index.test-d.ts
@@ -1,7 +1,6 @@
 import {expectType} from 'tsd-check';
 import {BrowserWindow} from 'electron';
-import electronDl from '.';
-import {download} from '.';
+import electronDl, {download} from '.';
 
 expectType<void>(electronDl());
 expectType<Electron.DownloadItem>(await download(new BrowserWindow(), 'test', {errorTitle: 'Nope'}));

--- a/package.json
+++ b/package.json
@@ -11,10 +11,11 @@
 	},
 	"scripts": {
 		"start": "electron run.js",
-		"test": "xo && ava"
+		"test": "xo && ava && tsd-check"
 	},
 	"files": [
-		"index.js"
+		"index.js",
+		"index.d.ts"
 	],
 	"keywords": [
 		"electron",
@@ -37,6 +38,7 @@
 		"node-static": "^0.7.9",
 		"pify": "^3.0.0",
 		"spectron": "^3.7.2",
+		"tsd-check": "^0.3.0",
 		"uuid": "^3.1.0",
 		"xo": "*"
 	},


### PR DESCRIPTION
Alright, gotta get started on those Caprine dependencies. Went through [the checklist](https://github.com/sindresorhus/typescript-definition-style-guide), hope I didn't miss anything.

One question: in Options, `directory` and `filename` do have "default values", but those aren't basic types, just a description. Should that be marked with `@default`?

---

Closes #69