### PR TITLE
Add `overwrite` option

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -68,6 +68,13 @@ export interface Options {
 	 * @default true
 	 */
 	readonly showBadge?: boolean;
+
+	/**
+	 * Allows downloaded files to overwrite files with the same name in the directory they are saved to.
+	 *
+	 * @default false
+	 */
+	readonly allowOverwrite?: boolean;
 }
 
 /**

--- a/index.d.ts
+++ b/index.d.ts
@@ -69,6 +69,13 @@ declare namespace electronDl {
 		@default true
 		*/
 		readonly showBadge?: boolean;
+		
+		/**
+		 * Allows downloaded files to overwrite files with the same name in the directory they are saved to.
+		 *
+		 * @default false
+		 */
+		readonly allowOverwrite?: boolean;
 	}
 }
 
@@ -91,13 +98,6 @@ declare const electronDl: {
 	```
 	*/
 	(options?: electronDl.Options): void;
-
-  /**
-	 * Allows downloaded files to overwrite files with the same name in the directory they are saved to.
-	 *
-	 * @default false
-	 */
-	readonly allowOverwrite?: boolean;
 }
 
   /**

--- a/index.d.ts
+++ b/index.d.ts
@@ -98,9 +98,8 @@ declare const electronDl: {
 	```
 	*/
 	(options?: electronDl.Options): void;
-}
 
-  /**
+  	/**
 	This can be useful if you need download functionality in a reusable module.
 
 	@param window - Window to register the behavior on.

--- a/index.d.ts
+++ b/index.d.ts
@@ -71,10 +71,10 @@ declare namespace electronDl {
 		readonly showBadge?: boolean;
 		
 		/**
-		 * Allows downloaded files to overwrite files with the same name in the directory they are saved to.
-		 *
-		 * @default false
-		 */
+		Allows downloaded files to overwrite files with the same name in the directory they are saved to.
+		
+		@default false
+		*/
 		readonly allowOverwrite?: boolean;
 	}
 }

--- a/index.js
+++ b/index.js
@@ -46,7 +46,11 @@ function registerListener(session, options, cb = () => {}) {
 			const filename = item.getFilename();
 			const name = path.extname(filename) ? filename : getFilenameFromMime(filename, item.getMimeType());
 
-			filePath = unusedFilename.sync(path.join(dir, name));
+			if (options.allowOverwrite) {
+				filePath = path.join(dir, name);
+			} else {
+				filePath = unusedFilename.sync(path.join(dir, name));
+			}
 		}
 
 		const errorMessage = options.errorMessage || 'The download of {filename} was interrupted';


### PR DESCRIPTION
I added an option that would allow downloaded files to overwrite files of the same name in the save directory. It is off by default. I had a use case for it where I wanted to have the program update itself from a remote server and I needed to overwrite existing files to do that. I think it would be nice to have the option to enable it.