### PR TITLE
Update `onProgress` docs

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -128,7 +128,7 @@ You can use this for advanced handling such as canceling the item like `item.can
 
 Type: `Function`
 
-Optional callback that receives a number between `0` and `1` representing the progress of the current download.
+Optional callback that receives a number between `0` and `1` representing the total progress of all the current downloads.
 
 #### onCancel
 


### PR DESCRIPTION
The progress value is not each individual download but all the current downloads, at least based on my experience with it (I might be doing something wrong).

So, if you download 3 items, you can't get the download progress of each individual file but instead for the total downloads.