### PR TITLE
Allow custom save dialog options

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -1,4 +1,4 @@
-import {BrowserWindow, DownloadItem, FileFilter, SaveDialogOptions} from 'electron';
+import {BrowserWindow, DownloadItem, SaveDialogOptions} from 'electron';
 
 declare namespace electronDl {
 	interface Options {

--- a/index.d.ts
+++ b/index.d.ts
@@ -1,4 +1,4 @@
-import {BrowserWindow, DownloadItem} from 'electron';
+import {BrowserWindow, DownloadItem, FileFilter, SaveDialogOptions} from 'electron';
 
 declare namespace electronDl {
 	interface Options {
@@ -25,6 +25,12 @@ declare namespace electronDl {
 		Default: [`downloadItem.getFilename()`](https://electronjs.org/docs/api/download-item/#downloaditemgetfilename)
 		*/
 		readonly filename?: string;
+
+		/**
+		 * Options for a custom save dialog
+		 * See https://electronjs.org/docs/api/dialog#dialogshowsavedialogsyncbrowserwindow-options
+		 */
+		readonly saveDialogOptions?: SaveDialogOptions;
 
 		/**
 		Title of the error dialog. Can be customized for localization.

--- a/index.js
+++ b/index.js
@@ -6,142 +6,161 @@ const pupa = require('pupa');
 const extName = require('ext-name');
 
 function getFilenameFromMime(name, mime) {
-	const exts = extName.mime(mime);
+  const exts = extName.mime(mime);
 
-	if (exts.length !== 1) {
-		return name;
-	}
+  if (exts.length !== 1) {
+    return name;
+  }
 
-	return `${name}.${exts[0].ext}`;
+  return `${name}.${exts[0].ext}`;
 }
 
 function registerListener(session, options, cb = () => {}) {
-	const downloadItems = new Set();
-	let receivedBytes = 0;
-	let completedBytes = 0;
-	let totalBytes = 0;
-	const activeDownloadItems = () => downloadItems.size;
-	const progressDownloadItems = () => receivedBytes / totalBytes;
+  const downloadItems = new Set();
+  let receivedBytes = 0;
+  let completedBytes = 0;
+  let totalBytes = 0;
+  const activeDownloadItems = () => downloadItems.size;
+  const progressDownloadItems = () => receivedBytes / totalBytes;
 
-	options = Object.assign({
-		showBadge: true
-	}, options);
+  options = Object.assign(
+    {
+      showBadge: true,
+      fileFilters: [],
+    },
+    options,
+  );
 
-	const listener = (e, item, webContents) => {
-		downloadItems.add(item);
-		totalBytes += item.getTotalBytes();
+  const listener = (e, item, webContents) => {
+    downloadItems.add(item);
+    totalBytes += item.getTotalBytes();
 
-		let hostWebContents = webContents;
-		if (webContents.getType() === 'webview') {
-			({hostWebContents} = webContents);
+    let hostWebContents = webContents;
+    if (webContents.getType() === 'webview') {
+      ({hostWebContents} = webContents);
+    }
+
+    const win = BrowserWindow.fromWebContents(hostWebContents);
+
+    const dir = options.directory || app.getPath('downloads');
+    let filePath;
+    if (options.filename) {
+      filePath = path.join(dir, options.filename);
+    } else {
+      const filename = item.getFilename();
+      const name = path.extname(filename)
+        ? filename
+        : getFilenameFromMime(filename, item.getMimeType());
+
+      filePath = unusedFilename.sync(path.join(dir, name));
+    }
+
+    const errorMessage =
+      options.errorMessage || 'The download of {filename} was interrupted';
+    const errorTitle = options.errorTitle || 'Download Error';
+
+    if (!options.saveAs) {
+      item.setSavePath(filePath);
+    } else if(options.saveDialogOptions) {
+      const fileName = dialog.showSaveDialogSync(saveDialogOptions);
+
+      if (typeof fileName == 'undefined') {
+		item.cancel();
+		if(options.unregisterWhenDone) {
+			session.removeListener('will-download', listener);
 		}
+      } else {
+        item.setSavePath(fileName);
+      }
+    }
 
-		const win = BrowserWindow.fromWebContents(hostWebContents);
+    if (typeof options.onStarted === 'function') {
+      options.onStarted(item);
+    }
 
-		const dir = options.directory || app.getPath('downloads');
-		let filePath;
-		if (options.filename) {
-			filePath = path.join(dir, options.filename);
-		} else {
-			const filename = item.getFilename();
-			const name = path.extname(filename) ? filename : getFilenameFromMime(filename, item.getMimeType());
+    item.on('updated', () => {
+      receivedBytes = [...downloadItems].reduce((receivedBytes, item) => {
+        receivedBytes += item.getReceivedBytes();
+        return receivedBytes;
+      }, completedBytes);
 
-			filePath = unusedFilename.sync(path.join(dir, name));
-		}
+      if (options.showBadge && ['darwin', 'linux'].includes(process.platform)) {
+        app.setBadgeCount(activeDownloadItems());
+      }
 
-		const errorMessage = options.errorMessage || 'The download of {filename} was interrupted';
-		const errorTitle = options.errorTitle || 'Download Error';
+      if (!win.isDestroyed()) {
+        win.setProgressBar(progressDownloadItems());
+      }
 
-		if (!options.saveAs) {
-			item.setSavePath(filePath);
-		}
+      if (typeof options.onProgress === 'function') {
+        options.onProgress(progressDownloadItems());
+      }
+    });
 
-		if (typeof options.onStarted === 'function') {
-			options.onStarted(item);
-		}
+    item.on('done', (event, state) => {
+      completedBytes += item.getTotalBytes();
+      downloadItems.delete(item);
 
-		item.on('updated', () => {
-			receivedBytes = [...downloadItems].reduce((receivedBytes, item) => {
-				receivedBytes += item.getReceivedBytes();
-				return receivedBytes;
-			}, completedBytes);
+      if (options.showBadge && ['darwin', 'linux'].includes(process.platform)) {
+        app.setBadgeCount(activeDownloadItems());
+      }
 
-			if (options.showBadge && ['darwin', 'linux'].includes(process.platform)) {
-				app.setBadgeCount(activeDownloadItems());
-			}
+      if (!win.isDestroyed() && !activeDownloadItems()) {
+        win.setProgressBar(-1);
+        receivedBytes = 0;
+        completedBytes = 0;
+        totalBytes = 0;
+      }
 
-			if (!win.isDestroyed()) {
-				win.setProgressBar(progressDownloadItems());
-			}
+      if (options.unregisterWhenDone) {
+        session.removeListener('will-download', listener);
+      }
 
-			if (typeof options.onProgress === 'function') {
-				options.onProgress(progressDownloadItems());
-			}
-		});
+      if (state === 'cancelled') {
+        if (typeof options.onCancel === 'function') {
+          options.onCancel(item);
+        }
+      } else if (state === 'interrupted') {
+        const message = pupa(errorMessage, {filename: item.getFilename()});
+        dialog.showErrorBox(errorTitle, message);
+        cb(new Error(message));
+      } else if (state === 'completed') {
+        if (process.platform === 'darwin') {
+          app.dock.downloadFinished(filePath);
+        }
 
-		item.on('done', (event, state) => {
-			completedBytes += item.getTotalBytes();
-			downloadItems.delete(item);
+        if (options.openFolderWhenDone) {
+          shell.showItemInFolder(path.join(dir, item.getFilename()));
+        }
 
-			if (options.showBadge && ['darwin', 'linux'].includes(process.platform)) {
-				app.setBadgeCount(activeDownloadItems());
-			}
+        cb(null, item);
+      }
+    });
+  };
 
-			if (!win.isDestroyed() && !activeDownloadItems()) {
-				win.setProgressBar(-1);
-				receivedBytes = 0;
-				completedBytes = 0;
-				totalBytes = 0;
-			}
-
-			if (options.unregisterWhenDone) {
-				session.removeListener('will-download', listener);
-			}
-
-			if (state === 'cancelled') {
-				if (typeof options.onCancel === 'function') {
-					options.onCancel(item);
-				}
-			} else if (state === 'interrupted') {
-				const message = pupa(errorMessage, {filename: item.getFilename()});
-				dialog.showErrorBox(errorTitle, message);
-				cb(new Error(message));
-			} else if (state === 'completed') {
-				if (process.platform === 'darwin') {
-					app.dock.downloadFinished(filePath);
-				}
-
-				if (options.openFolderWhenDone) {
-					shell.showItemInFolder(path.join(dir, item.getFilename()));
-				}
-
-				cb(null, item);
-			}
-		});
-	};
-
-	session.on('will-download', listener);
+  session.on('will-download', listener);
 }
 
 module.exports = (options = {}) => {
-	app.on('session-created', session => {
-		registerListener(session, options);
-	});
+  app.on('session-created', session => {
+    registerListener(session, options);
+  });
 };
 
 // TODO: Remove this for the next major release
 module.exports.default = module.exports;
 
-module.exports.download = (win, url, options) => new Promise((resolve, reject) => {
-	options = Object.assign({}, options, {unregisterWhenDone: true});
+module.exports.download = (win, url, options) =>
+  new Promise((resolve, reject) => {
+    options = Object.assign({}, options, {unregisterWhenDone: true});
 
-	registerListener(win.webContents.session, options, (err, item) => {
-		if (err) {
-			reject(err);
-		} else {
-			resolve(item);
-		}
-	});
+    registerListener(win.webContents.session, options, (err, item) => {
+      if (err) {
+        reject(err);
+      } else {
+        resolve(item);
+      }
+    });
 
-	win.webContents.downloadURL(url);
-});
+    win.webContents.downloadURL(url);
+  });

--- a/index.js
+++ b/index.js
@@ -6,161 +6,153 @@ const pupa = require('pupa');
 const extName = require('ext-name');
 
 function getFilenameFromMime(name, mime) {
-  const exts = extName.mime(mime);
+	const exts = extName.mime(mime);
 
-  if (exts.length !== 1) {
-    return name;
-  }
+	if (exts.length !== 1) {
+		return name;
+	}
 
-  return `${name}.${exts[0].ext}`;
+	return `${name}.${exts[0].ext}`;
 }
 
 function registerListener(session, options, cb = () => {}) {
-  const downloadItems = new Set();
-  let receivedBytes = 0;
-  let completedBytes = 0;
-  let totalBytes = 0;
-  const activeDownloadItems = () => downloadItems.size;
-  const progressDownloadItems = () => receivedBytes / totalBytes;
+	const downloadItems = new Set();
+	let receivedBytes = 0;
+	let completedBytes = 0;
+	let totalBytes = 0;
+	const activeDownloadItems = () => downloadItems.size;
+	const progressDownloadItems = () => receivedBytes / totalBytes;
 
-  options = Object.assign(
-    {
-      showBadge: true,
-      fileFilters: [],
-    },
-    options,
-  );
+	options = Object.assign({
+		showBadge: true
+	}, options);
 
-  const listener = (e, item, webContents) => {
-    downloadItems.add(item);
-    totalBytes += item.getTotalBytes();
+	const listener = (e, item, webContents) => {
+		downloadItems.add(item);
+		totalBytes += item.getTotalBytes();
 
-    let hostWebContents = webContents;
-    if (webContents.getType() === 'webview') {
-      ({hostWebContents} = webContents);
-    }
-
-    const win = BrowserWindow.fromWebContents(hostWebContents);
-
-    const dir = options.directory || app.getPath('downloads');
-    let filePath;
-    if (options.filename) {
-      filePath = path.join(dir, options.filename);
-    } else {
-      const filename = item.getFilename();
-      const name = path.extname(filename)
-        ? filename
-        : getFilenameFromMime(filename, item.getMimeType());
-
-      filePath = unusedFilename.sync(path.join(dir, name));
-    }
-
-    const errorMessage =
-      options.errorMessage || 'The download of {filename} was interrupted';
-    const errorTitle = options.errorTitle || 'Download Error';
-
-    if (!options.saveAs) {
-      item.setSavePath(filePath);
-    } else if(options.saveDialogOptions) {
-      const fileName = dialog.showSaveDialogSync(saveDialogOptions);
-
-      if (typeof fileName == 'undefined') {
-		item.cancel();
-		if(options.unregisterWhenDone) {
-			session.removeListener('will-download', listener);
+		let hostWebContents = webContents;
+		if (webContents.getType() === 'webview') {
+			({hostWebContents} = webContents);
 		}
-      } else {
-        item.setSavePath(fileName);
-      }
-    }
 
-    if (typeof options.onStarted === 'function') {
-      options.onStarted(item);
-    }
+		const win = BrowserWindow.fromWebContents(hostWebContents);
 
-    item.on('updated', () => {
-      receivedBytes = [...downloadItems].reduce((receivedBytes, item) => {
-        receivedBytes += item.getReceivedBytes();
-        return receivedBytes;
-      }, completedBytes);
+		const dir = options.directory || app.getPath('downloads');
+		let filePath;
+		if (options.filename) {
+			filePath = path.join(dir, options.filename);
+		} else {
+			const filename = item.getFilename();
+			const name = path.extname(filename) ? filename : getFilenameFromMime(filename, item.getMimeType());
 
-      if (options.showBadge && ['darwin', 'linux'].includes(process.platform)) {
-        app.setBadgeCount(activeDownloadItems());
-      }
+			filePath = unusedFilename.sync(path.join(dir, name));
+		}
 
-      if (!win.isDestroyed()) {
-        win.setProgressBar(progressDownloadItems());
-      }
+		const errorMessage = options.errorMessage || 'The download of {filename} was interrupted';
+		const errorTitle = options.errorTitle || 'Download Error';
 
-      if (typeof options.onProgress === 'function') {
-        options.onProgress(progressDownloadItems());
-      }
-    });
+		if (!options.saveAs) {
+			item.setSavePath(filePath);
+		} else if(options.saveDialogOptions) {
+			const fileName = dialog.showSaveDialogSync(saveDialogOptions);
+	  
+			if (typeof fileName == 'undefined') {
+			  item.cancel();
+			  if(options.unregisterWhenDone) {
+				  session.removeListener('will-download', listener);
+			  }
+			} else {
+			  item.setSavePath(fileName);
+			}
+		}
 
-    item.on('done', (event, state) => {
-      completedBytes += item.getTotalBytes();
-      downloadItems.delete(item);
+		if (typeof options.onStarted === 'function') {
+			options.onStarted(item);
+		}
 
-      if (options.showBadge && ['darwin', 'linux'].includes(process.platform)) {
-        app.setBadgeCount(activeDownloadItems());
-      }
+		item.on('updated', () => {
+			receivedBytes = [...downloadItems].reduce((receivedBytes, item) => {
+				receivedBytes += item.getReceivedBytes();
+				return receivedBytes;
+			}, completedBytes);
 
-      if (!win.isDestroyed() && !activeDownloadItems()) {
-        win.setProgressBar(-1);
-        receivedBytes = 0;
-        completedBytes = 0;
-        totalBytes = 0;
-      }
+			if (options.showBadge && ['darwin', 'linux'].includes(process.platform)) {
+				app.setBadgeCount(activeDownloadItems());
+			}
 
-      if (options.unregisterWhenDone) {
-        session.removeListener('will-download', listener);
-      }
+			if (!win.isDestroyed()) {
+				win.setProgressBar(progressDownloadItems());
+			}
 
-      if (state === 'cancelled') {
-        if (typeof options.onCancel === 'function') {
-          options.onCancel(item);
-        }
-      } else if (state === 'interrupted') {
-        const message = pupa(errorMessage, {filename: item.getFilename()});
-        dialog.showErrorBox(errorTitle, message);
-        cb(new Error(message));
-      } else if (state === 'completed') {
-        if (process.platform === 'darwin') {
-          app.dock.downloadFinished(filePath);
-        }
+			if (typeof options.onProgress === 'function') {
+				options.onProgress(progressDownloadItems());
+			}
+		});
 
-        if (options.openFolderWhenDone) {
-          shell.showItemInFolder(path.join(dir, item.getFilename()));
-        }
+		item.on('done', (event, state) => {
+			completedBytes += item.getTotalBytes();
+			downloadItems.delete(item);
 
-        cb(null, item);
-      }
-    });
-  };
+			if (options.showBadge && ['darwin', 'linux'].includes(process.platform)) {
+				app.setBadgeCount(activeDownloadItems());
+			}
 
-  session.on('will-download', listener);
+			if (!win.isDestroyed() && !activeDownloadItems()) {
+				win.setProgressBar(-1);
+				receivedBytes = 0;
+				completedBytes = 0;
+				totalBytes = 0;
+			}
+
+			if (options.unregisterWhenDone) {
+				session.removeListener('will-download', listener);
+			}
+
+			if (state === 'cancelled') {
+				if (typeof options.onCancel === 'function') {
+					options.onCancel(item);
+				}
+			} else if (state === 'interrupted') {
+				const message = pupa(errorMessage, {filename: item.getFilename()});
+				dialog.showErrorBox(errorTitle, message);
+				cb(new Error(message));
+			} else if (state === 'completed') {
+				if (process.platform === 'darwin') {
+					app.dock.downloadFinished(filePath);
+				}
+
+				if (options.openFolderWhenDone) {
+					shell.showItemInFolder(path.join(dir, item.getFilename()));
+				}
+
+				cb(null, item);
+			}
+		});
+	};
+
+	session.on('will-download', listener);
 }
 
 module.exports = (options = {}) => {
-  app.on('session-created', session => {
-    registerListener(session, options);
-  });
+	app.on('session-created', session => {
+		registerListener(session, options);
+	});
 };
 
 // TODO: Remove this for the next major release
 module.exports.default = module.exports;
 
-module.exports.download = (win, url, options) =>
-  new Promise((resolve, reject) => {
-    options = Object.assign({}, options, {unregisterWhenDone: true});
+module.exports.download = (win, url, options) => new Promise((resolve, reject) => {
+	options = Object.assign({}, options, {unregisterWhenDone: true});
 
-    registerListener(win.webContents.session, options, (err, item) => {
-      if (err) {
-        reject(err);
-      } else {
-        resolve(item);
-      }
-    });
+	registerListener(win.webContents.session, options, (err, item) => {
+		if (err) {
+			reject(err);
+		} else {
+			resolve(item);
+		}
+	});
 
-    win.webContents.downloadURL(url);
-  });
+	win.webContents.downloadURL(url);
+});


### PR DESCRIPTION
## Issue
`electron-dl` provides no way to specify custom options for the save dialog. For example, on Windows, a file extension filter is commonly provided.

## Fix
Add saveDialogOptions to `electron-dl`. If this property is specified, use `showSaveDialogSync` to set the filename instead of relying on the default behavior