### PR TITLE
Expose full progress info instead of only percentage

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -55,7 +55,7 @@ declare namespace electronDl {
 		/**
 		Optional callback that receives an object containing information about the progress of the current download item.
 		*/
-		readonly onProgress?: (progress: Progress | number) => void;
+		readonly onProgress?: (progress: Progress) => void;
 
 		/**
 		Optional callback that receives the [download item](https://electronjs.org/docs/api/download-item) for which the download has been cancelled.

--- a/index.d.ts
+++ b/index.d.ts
@@ -1,7 +1,7 @@
 import {BrowserWindow, DownloadItem} from 'electron';
 
 declare namespace electronDl {
-	interface ProgressUpdate {
+	interface Progress {
 		percent: number;
 		transferred: number;
 		total: number;
@@ -47,23 +47,15 @@ declare namespace electronDl {
 		readonly errorMessage?: string;
 
 		/**
-		If set to `true` the `onProgress` callback will receive an object containing additional information about the progress.
-
-		@default false
-		*/
-		readonly fullProgressUpdate?: boolean;
-
-		/**
 		Optional callback that receives the [download item](https://electronjs.org/docs/api/download-item).
 		You can use this for advanced handling such as canceling the item like `item.cancel()`.
 		*/
 		readonly onStarted?: (item: DownloadItem) => void;
 
 		/**
-		Optional callback that receives a number between `0` and `1` representing the progress of the current download
-		if `fullProgressUpdate` is `false` or an an object containing additional information about the progress otherwise.
+		Optional callback that receives an object containing information about the progress of the current download item.
 		*/
-		readonly onProgress?: (progressUpdate: ProgressUpdate | number) => void;
+		readonly onProgress?: (progress: Progress | number) => void;
 
 		/**
 		Optional callback that receives the [download item](https://electronjs.org/docs/api/download-item) for which the download has been cancelled.

--- a/index.d.ts
+++ b/index.d.ts
@@ -1,6 +1,12 @@
 import {BrowserWindow, DownloadItem} from 'electron';
 
 declare namespace electronDl {
+	interface ProgressUpdate {
+		percent: number;
+		transferred: number;
+		total: number;
+	}
+
 	interface Options {
 		/**
 		Show a `Save As…` dialog instead of downloading immediately.
@@ -41,15 +47,23 @@ declare namespace electronDl {
 		readonly errorMessage?: string;
 
 		/**
+		If set to `true` the `onProgress` callback will receive an object containing additional information about the progress.
+
+		@default false
+		*/
+		readonly fullProgressUpdate?: boolean;
+
+		/**
 		Optional callback that receives the [download item](https://electronjs.org/docs/api/download-item).
 		You can use this for advanced handling such as canceling the item like `item.cancel()`.
 		*/
 		readonly onStarted?: (item: DownloadItem) => void;
 
 		/**
-		Optional callback that receives a number between `0` and `1` representing the progress of the current download.
+		Optional callback that receives a number between `0` and `1` representing the progress of the current download
+		if `fullProgressUpdate` is `false` or an an object containing additional information about the progress otherwise.
 		*/
-		readonly onProgress?: (percent: number) => void;
+		readonly onProgress?: (progressUpdate: ProgressUpdate | number) => void;
 
 		/**
 		Optional callback that receives the [download item](https://electronjs.org/docs/api/download-item) for which the download has been cancelled.

--- a/index.d.ts
+++ b/index.d.ts
@@ -3,8 +3,8 @@ import {BrowserWindow, DownloadItem} from 'electron';
 declare namespace electronDl {
 	interface Progress {
 		percent: number;
-		transferred: number;
-		total: number;
+		transferredBytes: number;
+		totalBytes: number;
 	}
 
 	interface Options {

--- a/index.js
+++ b/index.js
@@ -75,13 +75,13 @@ function registerListener(session, options, cb = () => {}) {
 			}
 
 			if (typeof options.onProgress === 'function') {
-				const total = item.getTotalBytes();
-				const transferred = item.getReceivedBytes();
+				const itemTransferredBytes = item.getReceivedBytes();
+				const itemTotalBytes = item.getTotalBytes();
 
 				options.onProgress({
-					percent: total ? transferred / total : 0,
-					transferred,
-					total
+					percent: itemTotalBytes ? itemTransferredBytes / itemTotalBytes : 0,
+					transferredBytes: itemTransferredBytes,
+					totalBytes: itemTotalBytes
 				});
 			}
 		});

--- a/index.js
+++ b/index.js
@@ -75,15 +75,14 @@ function registerListener(session, options, cb = () => {}) {
 			}
 
 			if (typeof options.onProgress === 'function') {
-				if (options.fullProgressUpdate) {
-					options.onProgress({
-						percent: receivedBytes / totalBytes,
-						transferred: receivedBytes,
-						total: totalBytes
-					});
-				} else {
-					options.onProgress(progressDownloadItems());
-				}
+				const total = item.getTotalBytes();
+				const transferred = item.getReceivedBytes();
+
+				options.onProgress({
+					percent: itemTotal ? itemReceived / itemTotal : 0,
+					transferred,
+					total
+				});
 			}
 		});
 

--- a/index.js
+++ b/index.js
@@ -75,7 +75,15 @@ function registerListener(session, options, cb = () => {}) {
 			}
 
 			if (typeof options.onProgress === 'function') {
-				options.onProgress(progressDownloadItems());
+				if (options.fullProgressUpdate) {
+					options.onProgress({
+						percent: receivedBytes / totalBytes,
+						transferred: receivedBytes,
+						total: totalBytes
+					});
+				} else {
+					options.onProgress(progressDownloadItems());
+				}
 			}
 		});
 

--- a/index.js
+++ b/index.js
@@ -79,7 +79,7 @@ function registerListener(session, options, cb = () => {}) {
 				const transferred = item.getReceivedBytes();
 
 				options.onProgress({
-					percent: itemTotal ? itemReceived / itemTotal : 0,
+					percent: total ? transferred / total : 0,
 					transferred,
 					total
 				});

--- a/readme.md
+++ b/readme.md
@@ -133,8 +133,8 @@ Optional callback that receives an object containing information about the progr
 ```
 {
     percent: 0.1,
-    transferred: 100,
-    total: 1000
+    transferredBytes: 100,
+    totalBytes: 1000
 }
 ```
 

--- a/readme.md
+++ b/readme.md
@@ -117,6 +117,13 @@ Default: `The download of {filename} was interrupted`
 
 Message of the error dialog. `{filename}` is replaced with the name of the actual file. Can be customized for localization.
 
+#### fullProgressUpdate
+
+Type: `boolean`<br>
+Default: `false`
+
+If set to `true` the `onProgress` callback will receive an object containing additional information about the progress.
+
 #### onStarted
 
 Type: `Function`
@@ -128,7 +135,15 @@ You can use this for advanced handling such as canceling the item like `item.can
 
 Type: `Function`
 
-Optional callback that receives a number between `0` and `1` representing the progress of the current download.
+Optional callback that receives a number between `0` and `1` representing the progress of the current download if `fullProgressUpdate` is `false` or an an object containing additional information about the progress otherwise.
+
+```
+{
+    percent: 0.1,
+    transferred: 100,
+    total: 1000
+}
+```
 
 #### onCancel
 

--- a/readme.md
+++ b/readme.md
@@ -117,13 +117,6 @@ Default: `'The download of {filename} was interrupted'`
 
 Message of the error dialog. `{filename}` is replaced with the name of the actual file. Can be customized for localization.
 
-#### fullProgressUpdate
-
-Type: `boolean`<br>
-Default: `false`
-
-If set to `true` the `onProgress` callback will receive an object containing additional information about the progress.
-
 #### onStarted
 
 Type: `Function`
@@ -135,7 +128,7 @@ You can use this for advanced handling such as canceling the item like `item.can
 
 Type: `Function`
 
-Optional callback that receives a number between `0` and `1` representing the progress of the current download if `fullProgressUpdate` is `false` or an an object containing additional information about the progress otherwise.
+Optional callback that receives an object containing information about the progress of the current download item.
 
 ```
 {

--- a/readme.md
+++ b/readme.md
@@ -130,11 +130,11 @@ Type: `Function`
 
 Optional callback that receives an object containing information about the progress of the current download item.
 
-```
+```js
 {
-    percent: 0.1,
-    transferredBytes: 100,
-    totalBytes: 1000
+	percent: 0.1,
+	transferredBytes: 100,
+	totalBytes: 1000
 }
 ```
 


### PR DESCRIPTION
Adds the `fullProgressUpdate` option. When true, the `onProgress` callback receives an object containing additional information about transferred and total bytes, instead of only the percentage.

```
{
    percent: 0.1,
    transferredBytes: 1024,
    totalBytes: 10240
}
```