### PR TITLE
Remove Electron warning

### DIFF
--- a/index.js
+++ b/index.js
@@ -67,7 +67,7 @@ function registerListener(session, options, cb = () => {}) {
 			}, completedBytes);
 
 			if (options.showBadge && ['darwin', 'linux'].includes(process.platform)) {
-				app.setBadgeCount(activeDownloadItems());
+				app.badgeCount = activeDownloadItems();
 			}
 
 			if (!win.isDestroyed()) {
@@ -91,7 +91,7 @@ function registerListener(session, options, cb = () => {}) {
 			downloadItems.delete(item);
 
 			if (options.showBadge && ['darwin', 'linux'].includes(process.platform)) {
-				app.setBadgeCount(activeDownloadItems());
+				app.badgeCount = activeDownloadItems();
 			}
 
 			if (!win.isDestroyed() && !activeDownloadItems()) {

--- a/test/index.js
+++ b/test/index.js
@@ -32,7 +32,7 @@ test('download a single file', async t => {
 	await client.waitForExist(`[data-unique-filename="${t.context.files[0]}"]`);
 	await client.click(`[data-unique-filename="${t.context.files[0]}"]`);
 
-	t.is(await t.context.spectron.electron.remote.app.getBadgeCount(), 1);
+	t.is(await t.context.spectron.electron.remote.app.badgeCount(), 1);
 });
 
 test('download a couple files', async t => {
@@ -45,6 +45,6 @@ test('download a couple files', async t => {
 	await client.click(`[data-unique-filename="${t.context.files[2]}"]`);
 
 	// The first download appears to finish before the second is added sometimes
-	const badgeCount = await t.context.spectron.electron.remote.app.getBadgeCount();
+	const badgeCount = await t.context.spectron.electron.remote.app.badgeCount();
 	t.true(badgeCount === 1 || badgeCount === 2);
 });


### PR DESCRIPTION
Clear this warning message:
> (electron) 'setBadgeCount function' is deprecated and will be removed. Please use 'badgeCount property' instead.