### PR TITLE
Fix `openFolderWhenDone` sometimes selecting the wrong file

### DIFF
--- a/index.js
+++ b/index.js
@@ -119,7 +119,7 @@ function registerListener(session, options, callback = () => {}) {
 				}
 
 				if (options.openFolderWhenDone) {
-					shell.showItemInFolder(path.join(directory, item.getFilename()));
+					shell.showItemInFolder(filePath);
 				}
 
 				callback(null, item);


### PR DESCRIPTION
Closes #111