### PR TITLE
Improve error message for interrupted download

### DIFF
--- a/index.js
+++ b/index.js
@@ -110,7 +110,7 @@ function registerListener(session, options, callback = () => {}) {
 					options.onCancel(item);
 				}
 			} else if (state === 'interrupted') {
-				const message = pupa(errorMessage, {filename: item.getFilename()});
+				const message = pupa(errorMessage, {filename: path.basename(filePath)});
 				dialog.showErrorBox(errorTitle, message);
 				callback(new Error(message));
 			} else if (state === 'completed') {


### PR DESCRIPTION
Inspired by #112 

If a downloaded file is renamed via [unused-filename](https://github.com/sindresorhus/unused-filename/) (`file.txt` → `file (1).txt`), the error message for interrupted download will show the non-renamed filename. I believe showing the renamed filename is more helpful.