### PR TITLE
Don't show error dialog when download is interrupted in `electronDl.download()`

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -34,6 +34,7 @@ declare namespace electronDl {
 
 		/**
 		Title of the error dialog. Can be customized for localization.
+
 		Note: Error dialog will not be shown in `electronDl.download()`. Please handle error manually.
 
 		@default 'Download Error'
@@ -42,6 +43,7 @@ declare namespace electronDl {
 
 		/**
 		Message of the error dialog. `{filename}` is replaced with the name of the actual file. Can be customized for localization.
+
 		Note: Error dialog will not be shown in `electronDl.download()`. Please handle error manually.
 
 		@default 'The download of {filename} was interrupted'

--- a/index.d.ts
+++ b/index.d.ts
@@ -34,6 +34,7 @@ declare namespace electronDl {
 
 		/**
 		Title of the error dialog. Can be customized for localization.
+		Note: Error dialog will not be shown in `electronDl.download()`. Please handle error manually.
 
 		@default 'Download Error'
 		*/
@@ -41,6 +42,7 @@ declare namespace electronDl {
 
 		/**
 		Message of the error dialog. `{filename}` is replaced with the name of the actual file. Can be customized for localization.
+		Note: Error dialog will not be shown in `electronDl.download()`. Please handle error manually.
 
 		@default 'The download of {filename} was interrupted'
 		*/

--- a/index.js
+++ b/index.js
@@ -131,7 +131,7 @@ function registerListener(session, options, callback = () => {}) {
 module.exports = (options = {}) => {
 	app.on('session-created', session => {
 		registerListener(session, options, (error, _) => {
-			if (typeof error === typeof Error) {
+			if (error) {
 				const errorTitle = options.errorTitle || 'Download Error';
 				dialog.showErrorBox(errorTitle, error.message);
 			}

--- a/index.js
+++ b/index.js
@@ -50,7 +50,6 @@ function registerListener(session, options, callback = () => {}) {
 		}
 
 		const errorMessage = options.errorMessage || 'The download of {filename} was interrupted';
-		const errorTitle = options.errorTitle || 'Download Error';
 
 		if (!options.saveAs) {
 			item.setSavePath(filePath);
@@ -111,7 +110,6 @@ function registerListener(session, options, callback = () => {}) {
 				}
 			} else if (state === 'interrupted') {
 				const message = pupa(errorMessage, {filename: path.basename(filePath)});
-				dialog.showErrorBox(errorTitle, message);
 				callback(new Error(message));
 			} else if (state === 'completed') {
 				if (process.platform === 'darwin') {
@@ -132,7 +130,12 @@ function registerListener(session, options, callback = () => {}) {
 
 module.exports = (options = {}) => {
 	app.on('session-created', session => {
-		registerListener(session, options);
+		registerListener(session, options, (error, _) => {
+			if (typeof error === typeof Error) {
+				const errorTitle = options.errorTitle || 'Download Error';
+				dialog.showErrorBox(errorTitle, error.message);
+			}
+		});
 	});
 };
 

--- a/readme.md
+++ b/readme.md
@@ -109,12 +109,16 @@ Default: `'Download Error'`
 
 Title of the error dialog. Can be customized for localization.
 
+Note: Error dialog will not be shown in `electronDl.download()`. Please handle error manually.
+
 #### errorMessage
 
 Type: `string`\
 Default: `'The download of {filename} was interrupted'`
 
 Message of the error dialog. `{filename}` is replaced with the name of the actual file. Can be customized for localization.
+
+Note: Error dialog will not be shown in `electronDl.download()`. Please handle error manually.
 
 #### onStarted
 


### PR DESCRIPTION
This continues from #101 .

Moved error handling into `electronDl()`, therefore `electronDl.download()` will not pop up error dialog.