### PR TITLE
Add support for `BrowserView`

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -1,4 +1,4 @@
-import {BrowserWindow, DownloadItem} from 'electron';
+import {BrowserView, BrowserWindow, DownloadItem} from 'electron';
 
 declare namespace electronDl {
 	interface Progress {
@@ -121,7 +121,7 @@ declare const electronDl: {
 	```
 	*/
 	download(
-		window: BrowserWindow,
+		window: BrowserWindow | BrowserView,
 		url: string,
 		options?: electronDl.Options
 	): Promise<DownloadItem>;

--- a/index.js
+++ b/index.js
@@ -32,12 +32,29 @@ function registerListener(session, options, callback = () => {}) {
 		downloadItems.add(item);
 		totalBytes += item.getTotalBytes();
 
-		let hostWebContents = webContents;
-		if (webContents.getType() === 'webview') {
-			({hostWebContents} = webContents);
-		}
+		let window_;
 
-		const window_ = BrowserWindow.fromWebContents(hostWebContents);
+		const webContentsType = webContents.getType();
+		switch (webContentsType) {
+			case 'webview':
+				window_ = BrowserWindow.fromWebContents(webContents.hostWebContents);
+				break;
+			case 'browserView':
+				BrowserWindow.getAllWindows().forEach(currentWindow => {
+					currentWindow.getBrowserViews().some(currentBV => {
+						if (currentBV.webContents.id === webContents.id) {
+							window_ = currentWindow;
+							return true;
+						}
+
+						return false;
+					});
+				});
+				break;
+			default:
+				window_ = BrowserWindow.fromWebContents(webContents);
+				break;
+		}
 
 		const directory = options.directory || app.getPath('downloads');
 		let filePath;

--- a/index.js
+++ b/index.js
@@ -30,7 +30,7 @@ const getWindowFromBrowserView = webContents => {
 	}
 };
 
-const getWindowFromWebcontents = webContents => {
+const getWindowFromWebContents = webContents => {
 	let window_;
 	const webContentsType = webContents.getType();
 	switch (webContentsType) {
@@ -38,12 +38,7 @@ const getWindowFromWebcontents = webContents => {
 			window_ = BrowserWindow.fromWebContents(webContents.hostWebContents);
 			break;
 		case 'browserView':
-			if (majorElectronVersion() < 12) {
-				window_ = getWindowFromBrowserView(webContents);
-			} else {
-				window_ = BrowserWindow.fromWebContents(webContents);
-			}
-
+			window_ = getWindowFromBrowserView(webContents);
 			break;
 		default:
 			window_ = BrowserWindow.fromWebContents(webContents);
@@ -70,7 +65,7 @@ function registerListener(session, options, callback = () => {}) {
 		downloadItems.add(item);
 		totalBytes += item.getTotalBytes();
 
-		const window_ = getWindowFromWebcontents(webContents);
+		const window_ = majorElectronVersion() >= 12 ? BrowserWindow.fromWebContents(webContents) : getWindowFromWebContents(webContents);
 
 		const directory = options.directory || app.getPath('downloads');
 		let filePath;

--- a/readme.md
+++ b/readme.md
@@ -8,7 +8,7 @@
 - Saves the file to the users Downloads directory instead of prompting.
 - Bounces the Downloads directory in the dock when done. *(macOS)*
 - Handles multiple downloads.
-- Support for BrowserWindow and BrowserView.
+- Support for `BrowserWindow` and `BrowserView`.
 - Shows badge count *(macOS & Linux only)* and download progress. Example on macOS:
 
 <img src="screenshot.png" width="82">

--- a/readme.md
+++ b/readme.md
@@ -64,9 +64,9 @@ It can only be used in the [main](https://electronjs.org/docs/glossary/#main-pro
 
 ### window
 
-Type: `BrowserWindow` | `BrowserView`
+Type: `BrowserWindow | BrowserView`
 
-Window to register the behavior on. Alternatively a BrowserView can be passed along.
+Window to register the behavior on. Alternatively, a `BrowserView` can be passed.
 
 ### url
 

--- a/readme.md
+++ b/readme.md
@@ -8,6 +8,7 @@
 - Saves the file to the users Downloads directory instead of prompting.
 - Bounces the Downloads directory in the dock when done. *(macOS)*
 - Handles multiple downloads.
+- Support for BrowserWindow and BrowserView.
 - Shows badge count *(macOS & Linux only)* and download progress. Example on macOS:
 
 <img src="screenshot.png" width="82">
@@ -63,9 +64,9 @@ It can only be used in the [main](https://electronjs.org/docs/glossary/#main-pro
 
 ### window
 
-Type: `BrowserWindow`
+Type: `BrowserWindow` | `BrowserView`
 
-Window to register the behavior on.
+Window to register the behavior on. Alternatively a BrowserView can be passed along.
 
 ### url
 


### PR DESCRIPTION
In our app we are not currently using electron-dl, but electron-context-menu. using save image was breaking because electron-dl wasn't able to find the window.

This patch fixes that problem.

Unfortunately there can be many windows and several browserviews attached to each, so we need to iterate to find the right one as there is not a way to ask electron for it.