### PR TITLE
Fix ignored filename when using `saveAs` option

### DIFF
--- a/index.js
+++ b/index.js
@@ -53,7 +53,7 @@ function registerListener(session, options, callback = () => {}) {
 
 		if (!options.saveAs) {
 			item.setSavePath(filePath);
-		} else if(options.saveAs) { {
+		} else if(options.saveAs) {
 			item.setSaveDialogOptions({defaultPath: filePath});
 		}
 

--- a/index.js
+++ b/index.js
@@ -54,7 +54,7 @@ function registerListener(session, options, callback = () => {}) {
 		if (!options.saveAs) {
 			item.setSavePath(filePath);
 		} else {
-			item.setSaveDialogOptions({ defaultPath: filePath });
+			item.setSaveDialogOptions({defaultPath: filePath});
 		}
 
 		if (typeof options.onStarted === 'function') {

--- a/index.js
+++ b/index.js
@@ -51,10 +51,10 @@ function registerListener(session, options, callback = () => {}) {
 
 		const errorMessage = options.errorMessage || 'The download of {filename} was interrupted';
 
-		if (!options.saveAs) {
+		if (options.saveAs) {
+			item.setSaveDialogOptions({defaultPath: filePath});			
+		} else {
 			item.setSavePath(filePath);
-		} else if (options.saveAs) {
-			item.setSaveDialogOptions({defaultPath: filePath});
 		}
 
 		if (typeof options.onStarted === 'function') {

--- a/index.js
+++ b/index.js
@@ -53,7 +53,7 @@ function registerListener(session, options, callback = () => {}) {
 
 		if (!options.saveAs) {
 			item.setSavePath(filePath);
-		} else {
+		} else if(options.saveAs) { {
 			item.setSaveDialogOptions({defaultPath: filePath});
 		}
 

--- a/index.js
+++ b/index.js
@@ -53,7 +53,7 @@ function registerListener(session, options, callback = () => {}) {
 
 		if (!options.saveAs) {
 			item.setSavePath(filePath);
-		} else if(options.saveAs) {
+		} else if (options.saveAs) {
 			item.setSaveDialogOptions({defaultPath: filePath});
 		}
 

--- a/index.js
+++ b/index.js
@@ -52,7 +52,7 @@ function registerListener(session, options, callback = () => {}) {
 		const errorMessage = options.errorMessage || 'The download of {filename} was interrupted';
 
 		if (options.saveAs) {
-			item.setSaveDialogOptions({defaultPath: filePath});			
+			item.setSaveDialogOptions({defaultPath: filePath});
 		} else {
 			item.setSavePath(filePath);
 		}

--- a/index.js
+++ b/index.js
@@ -53,6 +53,8 @@ function registerListener(session, options, callback = () => {}) {
 
 		if (!options.saveAs) {
 			item.setSavePath(filePath);
+		} else {
+			item.setSaveDialogOptions({ defaultPath: filePath });
 		}
 
 		if (typeof options.onStarted === 'function') {


### PR DESCRIPTION
The current implementation ignores the filename when using the option saveAs.
This PR will fix the above issue and will set the saveDialogOptions default path to the file path given.

Referenced issues: 
Fixes #59
Fixes #79