### PR TITLE
Add `onCompleted` and `onTotalProgress` options

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -8,7 +8,7 @@ declare namespace electronDl {
 	}
 	
 	interface File {
-		fileName: string,
+		filename: string,
 		path: string,
 		fileSize: number,
 		mimeType: string,

--- a/index.d.ts
+++ b/index.d.ts
@@ -72,7 +72,7 @@ declare namespace electronDl {
 		/**
 		Optional callback that receives an object containing information about the combined progress of all download items done within any registered window.
 		
-		Each time a new download is started, the next callback will include it. The progress percentage would therefore become smaller again, for example.
+		Each time a new download is started, the next callback will include it. The progress percentage could therefore become smaller again.
 		This callback provides the same data that is used for the progress bar on the app icon.
 		*/
 		readonly onTotalProgress?: (file: File) => void;

--- a/index.d.ts
+++ b/index.d.ts
@@ -6,6 +6,14 @@ declare namespace electronDl {
 		transferredBytes: number;
 		totalBytes: number;
 	}
+	
+	interface Completed {
+		fileName: string,
+		path: string,
+		fileSize: number,
+		mimeType: string,
+		url: string
+	}
 
 	interface Options {
 		/**
@@ -60,11 +68,21 @@ declare namespace electronDl {
 		Optional callback that receives an object containing information about the progress of the current download item.
 		*/
 		readonly onProgress?: (progress: Progress) => void;
+		
+		/**
+		Optional callback that receives an object containing information about the total progress of all download items.
+		*/
+		readonly onTotalProgress?: (progress: Progress) => void;
 
 		/**
 		Optional callback that receives the [download item](https://electronjs.org/docs/api/download-item) for which the download has been cancelled.
 		*/
 		readonly onCancel?: (item: DownloadItem) => void;
+		
+		/**
+		Optional callback that receives an object containing information about the completed download file.
+		*/
+		readonly onCompleted?: (completed: Completed) => void;
 
 		/**
 		Reveal the downloaded file in the system file manager, and if possible, select the file.

--- a/index.d.ts
+++ b/index.d.ts
@@ -7,7 +7,7 @@ declare namespace electronDl {
 		totalBytes: number;
 	}
 	
-	interface Completed {
+	interface File {
 		fileName: string,
 		path: string,
 		fileSize: number,

--- a/index.d.ts
+++ b/index.d.ts
@@ -70,9 +70,12 @@ declare namespace electronDl {
 		readonly onProgress?: (progress: Progress) => void;
 		
 		/**
-		Optional callback that receives an object containing information about the total progress of all download items.
+		Optional callback that receives an object containing information about the combined progress of all download items done within any registered window.
+		
+		Each time a new download is started, the next callback will include it. The progress percentage would therefore become smaller again, for example.
+		This callback provides the same data that is used for the progress bar on the app icon.
 		*/
-		readonly onTotalProgress?: (progress: Progress) => void;
+		readonly onTotalProgress?: (file: File) => void;
 
 		/**
 		Optional callback that receives the [download item](https://electronjs.org/docs/api/download-item) for which the download has been cancelled.
@@ -80,7 +83,7 @@ declare namespace electronDl {
 		readonly onCancel?: (item: DownloadItem) => void;
 		
 		/**
-		Optional callback that receives an object containing information about the completed download file.
+		Optional callback that receives an object with information about an item that has been completed. It is called for each completed item.
 		*/
 		readonly onCompleted?: (completed: Completed) => void;
 

--- a/index.js
+++ b/index.js
@@ -83,6 +83,14 @@ function registerListener(session, options, callback = () => {}) {
 					totalBytes: itemTotalBytes
 				});
 			}
+
+			if (typeof options.onTotalProgress === 'function') {
+				options.onTotalProgress({
+					percent: progressDownloadItems(),
+					transferredBytes: receivedBytes,
+					totalBytes
+				});
+			}
 		});
 
 		item.on('done', (event, state) => {
@@ -118,6 +126,16 @@ function registerListener(session, options, callback = () => {}) {
 
 				if (options.openFolderWhenDone) {
 					shell.showItemInFolder(filePath);
+				}
+
+				if (typeof options.onCompleted === 'function') {
+					options.onCompleted({
+						fileName: item.getFilename(),
+						path: item.getSavePath(),
+						fileSize: item.getReceivedBytes(),
+						mimeType: item.getMimeType(),
+						url: item.getURL()
+					});
 				}
 
 				callback(null, item);

--- a/readme.md
+++ b/readme.md
@@ -149,9 +149,9 @@ Optional callback that receives an object containing information about the total
 
 ```js
 {
-percent: 0.1,
-transferredBytes: 100,
-totalBytes: 1000
+	percent: 0.1,
+	transferredBytes: 100,
+	totalBytes: 1000
 }
 ```
 
@@ -169,11 +169,11 @@ Optional callback that receives an object containing information about the compl
 
 ```js
 {
-fileName: 'file.zip',
-path: '/path/file.zip',
-fileSize: 503320,
-mimeType: 'application/zip',
-url: 'https://example.com/file.zip'
+	filename: 'file.zip',
+	path: '/path/file.zip',
+	fileSize: 503320,
+	mimeType: 'application/zip',
+	url: 'https://example.com/file.zip'
 }
 
 #### openFolderWhenDone

--- a/readme.md
+++ b/readme.md
@@ -147,7 +147,7 @@ Type: `Function`
 
 Optional callback that receives an object containing information about the combined progress of all download items done within any registered window.
 
-Each time a new download is started, the next callback will include it. The progress percentage would therefore become smaller again, for example.
+Each time a new download is started, the next callback will include it. The progress percentage could therefore become smaller again.
 This callback provides the same data that is used for the progress bar on the app icon.
 
 ```js

--- a/readme.md
+++ b/readme.md
@@ -141,11 +141,40 @@ Optional callback that receives an object containing information about the progr
 }
 ```
 
+#### onTotalProgress
+
+Type: `Function`
+
+Optional callback that receives an object containing information about the total progress of all download items.
+
+```js
+{
+percent: 0.1,
+transferredBytes: 100,
+totalBytes: 1000
+}
+```
+
 #### onCancel
 
 Type: `Function`
 
 Optional callback that receives the [download item](https://electronjs.org/docs/api/download-item) for which the download has been cancelled.
+
+#### onCompleted
+
+Type: `Function`
+
+Optional callback that receives an object containing information about the completed download file.
+
+```js
+{
+fileName: 'file.zip',
+path: '/path/file.zip',
+fileSize: 503320,
+mimeType: 'application/zip',
+url: 'https://example.com/file.zip'
+}
 
 #### openFolderWhenDone
 

--- a/readme.md
+++ b/readme.md
@@ -145,7 +145,10 @@ Optional callback that receives an object containing information about the progr
 
 Type: `Function`
 
-Optional callback that receives an object containing information about the total progress of all download items.
+Optional callback that receives an object containing information about the combined progress of all download items done within any registered window.
+
+Each time a new download is started, the next callback will include it. The progress percentage would therefore become smaller again, for example.
+This callback provides the same data that is used for the progress bar on the app icon.
 
 ```js
 {
@@ -165,7 +168,7 @@ Optional callback that receives the [download item](https://electronjs.org/docs/
 
 Type: `Function`
 
-Optional callback that receives an object containing information about the completed download file.
+Optional callback that receives an object with information about an item that has been completed. It is called for each completed item.
 
 ```js
 {


### PR DESCRIPTION
I am using electron-dl with `electronDl();` and `win.webContents.downloadURL(url);` and needed a way to get the total progress of all download files and a callback when a file is finished to display a notification.

I am not 100% certain this is the best way to solve this problem so feel free to close this pull request but I think it might be useful for other people as well and it fixes #110. 