### PR TITLE
Fix TypeScript types

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -75,7 +75,7 @@ declare namespace electronDl {
 		Each time a new download is started, the next callback will include it. The progress percentage could therefore become smaller again.
 		This callback provides the same data that is used for the progress bar on the app icon.
 		*/
-		readonly onTotalProgress?: (file: File) => void;
+		readonly onTotalProgress?: (progress: Progress) => void;
 
 		/**
 		Optional callback that receives the [download item](https://electronjs.org/docs/api/download-item) for which the download has been cancelled.
@@ -85,7 +85,7 @@ declare namespace electronDl {
 		/**
 		Optional callback that receives an object with information about an item that has been completed. It is called for each completed item.
 		*/
-		readonly onCompleted?: (completed: { fileName: string; path: string; fileSize: number; mimeType: string; url: string }) => void;
+		readonly onCompleted?: (file: File) => void;
 
 		/**
 		Reveal the downloaded file in the system file manager, and if possible, select the file.

--- a/index.d.ts
+++ b/index.d.ts
@@ -85,7 +85,7 @@ declare namespace electronDl {
 		/**
 		Optional callback that receives an object with information about an item that has been completed. It is called for each completed item.
 		*/
-		readonly onCompleted?: (completed: Completed) => void;
+		readonly onCompleted?: (completed: { fileName: string; path: string; fileSize: number; mimeType: string; url: string }) => void;
 
 		/**
 		Reveal the downloaded file in the system file manager, and if possible, select the file.


### PR DESCRIPTION
`Completed` was not recognised as a valid type and I was not able to find something within electron or your library which matches this term.

So I added the types manually based on the `onCompleted` call from `index.js`.

The current version was not working in my typescript project, at least not without additional changes to add this `Completed` type.