### PR TITLE
Enable TSD again

### DIFF
--- a/package.json
+++ b/package.json
@@ -11,9 +11,8 @@
 		"url": "sindresorhus.com"
 	},
 	"scripts": {
-		"//": "Enable tsd again when the Electron issue is fixed",
 		"start": "electron run.js",
-		"test": "xo && ava"
+		"test": "xo && ava && tsd"
 	},
 	"files": [
 		"index.js",
@@ -41,7 +40,7 @@
 		"node-static": "^0.7.11",
 		"pify": "^4.0.1",
 		"spectron": "^9.0.0",
-		"tsd": "^0.11.0",
+		"tsd": "^0.17.0",
 		"uuid": "^3.3.2",
 		"xo": "^0.25.3"
 	},


### PR DESCRIPTION
Running `npx tsd` with 0.11.0 raises
```
  node_modules/electron/electron.d.ts:1657:30
  ✖  1657:30  Cannot extend an interface NodeJS.EventEmitter. Did you mean implements?  
  ✖  2994:30  Cannot extend an interface NodeJS.EventEmitter. Did you mean implements? 
  ...
  18 errors
```
but upgrading to 0.17.0 fixes these problems, and runs with no errors/warnings.

Not sure what the original Electron issue was that was preventing TSD running, but it seems to work properly now.