### PR TITLE
Call the callback when state is cancelled

### DIFF
--- a/index.js
+++ b/index.js
@@ -209,3 +209,5 @@ module.exports.download = (window_, url, options) => new Promise((resolve, rejec
 
 	window_.webContents.downloadURL(url);
 });
+
+module.exports.CancelError = CancelError;

--- a/index.js
+++ b/index.js
@@ -5,6 +5,8 @@ const unusedFilename = require('unused-filename');
 const pupa = require('pupa');
 const extName = require('ext-name');
 
+class CancelError extends Error {}
+
 const getFilenameFromMime = (name, mime) => {
 	const extensions = extName.mime(mime);
 
@@ -148,6 +150,8 @@ function registerListener(session, options, callback = () => {}) {
 				if (typeof options.onCancel === 'function') {
 					options.onCancel(item);
 				}
+
+				callback(new CancelError());
 			} else if (state === 'interrupted') {
 				const message = pupa(errorMessage, {filename: path.basename(filePath)});
 				callback(new Error(message));


### PR DESCRIPTION
To prevent the `download` function from never resolving the `callback` needs to be called. Today, if you call `downloadItem.cancel()` on one of the item, the main `download(win, options)` function will not return.

The fix is using a new `CancelError` as the callback argument, as proposed in the #115 discussion.