### PR TITLE
Support relative paths if `options.directory` starts with "."

### DIFF
--- a/index.js
+++ b/index.js
@@ -67,7 +67,11 @@ function registerListener(session, options, callback = () => {}) {
 
 		const window_ = majorElectronVersion() >= 12 ? BrowserWindow.fromWebContents(webContents) : getWindowFromWebContents(webContents);
 
-		const directory = options.directory || app.getPath('downloads');
+		let directory = options.directory || app.getPath('downloads');
+		if (directory.match(/^\./)) {
+			// relative path, so join to AppPath
+			directory = path.join(app.getAppPath(), directory);
+		}
 		let filePath;
 		if (options.filename) {
 			filePath = path.join(directory, options.filename);

--- a/index.js
+++ b/index.js
@@ -68,10 +68,7 @@ function registerListener(session, options, callback = () => {}) {
 		const window_ = majorElectronVersion() >= 12 ? BrowserWindow.fromWebContents(webContents) : getWindowFromWebContents(webContents);
 
 		let directory = options.directory || app.getPath('downloads');
-		if (directory.match(/^\./)) {
-			// relative path, so join to AppPath
-			directory = path.join(app.getAppPath(), directory);
-		}
+		directory = path.resolve(directory); // converts any relative path to absolute path
 		let filePath;
 		if (options.filename) {
 			filePath = path.join(directory, options.filename);


### PR DESCRIPTION
I noticed that relative paths didn't work correctly and that the simple fix would be to determine if the `options.directory` started with a period (to handle "." and "..") and then do `path.join(app.getAppPath(), directory)` which will spit out an absolute path. (#125)

Does not currently handle "~/" but that could be done pretty easily if needed. 