### PR TITLE
Add `showProgressBar` option

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -104,6 +104,13 @@ declare namespace electronDl {
 		readonly showBadge?: boolean;
 
 		/**
+		Shows the progress bar when download is in progress.
+
+		@default true
+		*/
+		readonly showProgressBar?: boolean;
+
+		/**
 		Allow downloaded files to overwrite files with the same name in the directory they are saved to.
 
 		The default behavior is to append a number to the filename.

--- a/index.d.ts
+++ b/index.d.ts
@@ -97,14 +97,14 @@ declare namespace electronDl {
 		readonly openFolderWhenDone?: boolean;
 
 		/**
-		Shows the file count badge on macOS/Linux dock icons when download is in progress.
+		Show a file count badge on the macOS/Linux dock/taskbar icon when a download is in progress.
 
 		@default true
 		*/
 		readonly showBadge?: boolean;
 
 		/**
-		Shows the progress bar when download is in progress.
+		Show a progress bar on the dock/taskbar icon when a download is in progress.
 
 		@default true
 		*/

--- a/index.js
+++ b/index.js
@@ -58,6 +58,7 @@ function registerListener(session, options, callback = () => {}) {
 
 	options = {
 		showBadge: true,
+		showProgressBar: true,
 		...options
 	};
 
@@ -105,7 +106,7 @@ function registerListener(session, options, callback = () => {}) {
 				app.badgeCount = activeDownloadItems();
 			}
 
-			if (!window_.isDestroyed()) {
+			if (!window_.isDestroyed() && options.showProgressBar) {
 				window_.setProgressBar(progressDownloadItems());
 			}
 

--- a/readme.md
+++ b/readme.md
@@ -195,14 +195,14 @@ Reveal the downloaded file in the system file manager, and if possible, select t
 Type: `boolean`\
 Default: `true`
 
-Shows the file count badge on macOS/Linux dock icons when download is in progress.
+Show a file count badge on the macOS/Linux dock/taskbar icon when a download is in progress.
 
 #### showProgressBar
 
 Type: `boolean`\
 Default: `true`
 
-Shows the progress bar when download is in progress.
+Show a progress bar on the dock/taskbar icon when a download is in progress.
 
 #### overwrite
 

--- a/readme.md
+++ b/readme.md
@@ -197,6 +197,13 @@ Default: `true`
 
 Shows the file count badge on macOS/Linux dock icons when download is in progress.
 
+#### showProgressBar
+
+Type: `boolean`\
+Default: `true`
+
+Shows the progress bar when download is in progress.
+
 #### overwrite
 
 Type: `boolean`\


### PR DESCRIPTION
Sometimes we don't want to show the progress bar while downloading, so I make it as an option.