### PR TITLE
await download() will not stuck if item.cancel() was called

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -130,8 +130,18 @@ declare namespace electronDl {
 	}
 }
 
+/**
+ * Error thrown if `item.cancel()` was called.
+*/
+declare class CancelError extends Error {}
+
 // eslint-disable-next-line no-redeclare
 declare const electronDl: {
+	/**
+	 * The error thrown when the user cancels the download item.
+	*/
+	CancelError: typeof CancelError;
+
 	/**
 	Register the helper for all windows.
 
@@ -157,6 +167,8 @@ declare const electronDl: {
 	@param window - Window to register the behavior on.
 	@param url - URL to download.
 	@returns A promise for the downloaded file.
+	@throws {CancelError} An error if the user calls item.cancel().
+	@throws {Error} An error if the download fails.
 
 	@example
 	```

--- a/index.d.ts
+++ b/index.d.ts
@@ -167,7 +167,7 @@ declare const electronDl: {
 	@param window - Window to register the behavior on.
 	@param url - URL to download.
 	@returns A promise for the downloaded file.
-	@throws {CancelError} An error if the user calls item.cancel().
+	@throws {CancelError} An error if the user calls `item.cancel()`.
 	@throws {Error} An error if the download fails.
 
 	@example

--- a/index.d.ts
+++ b/index.d.ts
@@ -131,14 +131,14 @@ declare namespace electronDl {
 }
 
 /**
- * Error thrown if `item.cancel()` was called.
+Error thrown if `item.cancel()` was called.
 */
 declare class CancelError extends Error {}
 
 // eslint-disable-next-line no-redeclare
 declare const electronDl: {
 	/**
-	 * The error thrown when the user cancels the download item.
+	Error thrown if `item.cancel()` was called.
 	*/
 	CancelError: typeof CancelError;
 

--- a/index.js
+++ b/index.js
@@ -181,11 +181,11 @@ function registerListener(session, options, callback = () => {}) {
 				callback(null, item);
 			}
 		});
-	};
 
-	if (typeof options.onStarted === 'function') {
-		options.onStarted(item);
-	}
+		if (typeof options.onStarted === 'function') {
+			options.onStarted(item);
+		}
+	};
 
 	session.on('will-download', listener);
 }
@@ -217,3 +217,5 @@ module.exports.download = (window_, url, options) => new Promise((resolve, rejec
 
 	window_.webContents.downloadURL(url);
 });
+
+module.exports.CancelError = CancelError

--- a/index.js
+++ b/index.js
@@ -218,4 +218,4 @@ module.exports.download = (window_, url, options) => new Promise((resolve, rejec
 	window_.webContents.downloadURL(url);
 });
 
-module.exports.CancelError = CancelError
+module.exports.CancelError = CancelError;

--- a/readme.md
+++ b/readme.md
@@ -50,7 +50,15 @@ const {download} = require('electron-dl');
 
 ipcMain.on('download-button', async (event, {url}) => {
  	const win = BrowserWindow.getFocusedWindow();
- 	console.log(await download(win, url));
+     try {
+         console.log(await download(win, url));
+     } catch (error) {
+         if (error instanceof electronDl.CancelError) {
+         	console.info('item.cancel() was called');
+		 } else {
+		 	console.error(error);
+		 }
+	 }
 });
 ```
 
@@ -128,7 +136,7 @@ Note: Error dialog will not be shown in `electronDl.download()`. Please handle e
 Type: `Function`
 
 Optional callback that receives the [download item](https://electronjs.org/docs/api/download-item).
-You can use this for advanced handling such as canceling the item like `item.cancel()`.
+You can use this for advanced handling such as canceling the item like `item.cancel()` which will throw `electronDl.CancelError` from `electronDl.download()` method.
 
 #### onProgress
 

--- a/readme.md
+++ b/readme.md
@@ -136,7 +136,7 @@ Note: Error dialog will not be shown in `electronDl.download()`. Please handle e
 Type: `Function`
 
 Optional callback that receives the [download item](https://electronjs.org/docs/api/download-item).
-You can use this for advanced handling such as canceling the item like `item.cancel()` which will throw `electronDl.CancelError` from `electronDl.download()` method.
+You can use this for advanced handling such as canceling the item like `item.cancel()` which will throw `electronDl.CancelError` from the `electronDl.download()` method.
 
 #### onProgress
 


### PR DESCRIPTION
based on #142 
fixes #115 
also it was not possible to call `item.cancel()` from `onStart` because of wrong code order