### PR TITLE
feat: add optional onError callback options key

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -90,6 +90,12 @@ declare namespace electronDl {
 		readonly onCompleted?: (file: File) => void;
 
 		/**
+		Optional callback that receives an error title and an error message. It is called every time when download state is "interrupted".
+		If callback is not provided error will be shown in Electron error dialog.
+		*/
+		readonly onError?: (errorTitle: string, errorMessage: string) => void;
+
+		/**
 		Reveal the downloaded file in the system file manager, and if possible, select the file.
 
 		@default false

--- a/index.js
+++ b/index.js
@@ -195,7 +195,11 @@ module.exports = (options = {}) => {
 		registerListener(session, options, (error, _) => {
 			if (error && !(error instanceof CancelError)) {
 				const errorTitle = options.errorTitle || 'Download Error';
-				dialog.showErrorBox(errorTitle, error.message);
+				if ('onError' in options && typeof options.onError === 'function') {
+					options.onError(errorTitle, error.message);
+				} else {
+					dialog.showErrorBox(errorTitle, error.message);
+				}
 			}
 		});
 	});

--- a/readme.md
+++ b/readme.md
@@ -197,6 +197,7 @@ Type: `Function`
 
 Optional callback that receives an error title and an error message. It is called every time when download state is "interrupted".
 If callback is not provided error will be shown in Electron error dialog.
+(*is applied only in default exported function, not for usage inside 'download' function)
 
 #### openFolderWhenDone
 

--- a/readme.md
+++ b/readme.md
@@ -191,6 +191,13 @@ Optional callback that receives an object with information about an item that ha
 }
 ```
 
+#### onError
+
+Type: `Function`
+
+Optional callback that receives an error title and an error message. It is called every time when download state is "interrupted".
+If callback is not provided error will be shown in Electron error dialog.
+
 #### openFolderWhenDone
 
 Type: `boolean`\


### PR DESCRIPTION
Hi, I would like to have an ability to handle interrupted errors by myself. Now all the errors are shown in Electron error dialog. For this I propose to have 'onError' optional callback in options. Cheers.