### PR TITLE
Update index.d.ts to loosen type restriction on download

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -3,6 +3,7 @@ import {
 	type BrowserWindow,
 	type DownloadItem,
 	type SaveDialogOptions,
+	type WebContents,
 } from 'electron';
 
 export type Progress = {
@@ -178,7 +179,7 @@ ipcMain.on('download-button', async (event, {url}) => {
 ```
 */
 export function download(
-	window: BrowserWindow | BrowserView,
+	window: { webContents: Electron.WebContents },
 	url: string,
 	options?: Options
 ): Promise<DownloadItem>;


### PR DESCRIPTION
Electron has recently WebContentsView which is not included in the types expected by download. Since download only uses the webContents property, I suggest we loosen the type to anything that has that property. This would make it useful for anything that gets added in the futur too. 