### PR TITLE
Support automatic resumption of interrupted downloads

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -131,6 +131,14 @@ export type Options = {
 	@default {}
 	*/
 	readonly dialogOptions?: SaveDialogOptions;
+
+	/**
+	Optional. Specifies how many times the download should automatically attempt (attempt every second) to resume if it is interrupted and can be resumed.
+	If the download cannot be resumed after the specified number of attempts, it will be aborted.
+
+	@default 60
+	*/
+	readonly retryLimit?: number;
 };
 
 /**

--- a/index.js
+++ b/index.js
@@ -38,6 +38,8 @@ function registerListener(session, options, callback = () => {}) {
 
 	const listener = (event, item, webContents) => {
 		let currentRetry = 0;
+		let itemLastTransferredBytes = 0;
+
 		downloadItems.add(item);
 		totalBytes += item.getTotalBytes();
 
@@ -72,6 +74,7 @@ function registerListener(session, options, callback = () => {}) {
 
 		item.on('updated', (event, state) => {
 			const retryLimit = options.retryLimit ?? 60;
+			let hasTransferredBytesChanged = false;
 
 			receivedBytes = completedBytes;
 			for (const item of downloadItems) {
@@ -86,10 +89,13 @@ function registerListener(session, options, callback = () => {}) {
 				window_.setProgressBar(progressDownloadItems());
 			}
 
-			if (typeof options.onProgress === 'function') {
-				const itemTransferredBytes = item.getReceivedBytes();
-				const itemTotalBytes = item.getTotalBytes();
+			const itemTransferredBytes = item.getReceivedBytes();
+			const itemTotalBytes = item.getTotalBytes();
+			const toleranceBytes = 1024 * 50;
+			hasTransferredBytesChanged = itemTransferredBytes > itemLastTransferredBytes + toleranceBytes;
+			itemLastTransferredBytes = itemTransferredBytes;
 
+			if (typeof options.onProgress === 'function') {
 				options.onProgress({
 					percent: itemTotalBytes ? itemTransferredBytes / itemTotalBytes : 0,
 					transferredBytes: itemTransferredBytes,
@@ -118,7 +124,7 @@ function registerListener(session, options, callback = () => {}) {
 				}
 			}
 
-			if (state === 'progressing') {
+			if (hasTransferredBytesChanged) {
 				currentRetry = 0;
 			}
 		});
@@ -198,6 +204,7 @@ export default function electronDl(options = {}) {
 }
 
 export async function download(window_, url, options) {
+	console.log('xxxxxx', url, options);
 	return new Promise((resolve, reject) => {
 		options = {
 			...options,

--- a/index.js
+++ b/index.js
@@ -37,6 +37,7 @@ function registerListener(session, options, callback = () => {}) {
 	};
 
 	const listener = (event, item, webContents) => {
+		let currentRetry = 0;
 		downloadItems.add(item);
 		totalBytes += item.getTotalBytes();
 
@@ -69,7 +70,9 @@ function registerListener(session, options, callback = () => {}) {
 			item.setSavePath(filePath);
 		}
 
-		item.on('updated', () => {
+		item.on('updated', (event, state) => {
+			const retryLimit = options.retryLimit ?? 60;
+
 			receivedBytes = completedBytes;
 			for (const item of downloadItems) {
 				receivedBytes += item.getReceivedBytes();
@@ -100,6 +103,24 @@ function registerListener(session, options, callback = () => {}) {
 					transferredBytes: receivedBytes,
 					totalBytes,
 				});
+			}
+
+			if (state === 'interrupted') {
+				if (item.canResume() && currentRetry != retryLimit) {
+					setTimeout(() => {
+						item.resume();
+						currentRetry++;
+					}, 1000);
+				}
+				else {
+					const message = pupa(errorMessage, {filename: path.basename(filePath)});
+					callback(new Error(message));
+					item.cancel();
+				}
+			}
+
+			if (state === 'progressing') {
+				currentRetry = 0;
 			}
 		});
 

--- a/index.js
+++ b/index.js
@@ -106,13 +106,12 @@ function registerListener(session, options, callback = () => {}) {
 			}
 
 			if (state === 'interrupted') {
-				if (item.canResume() && currentRetry != retryLimit) {
+				if (item.canResume() && currentRetry !== retryLimit) {
 					setTimeout(() => {
 						item.resume();
 						currentRetry++;
 					}, 1000);
-				}
-				else {
+				} else {
 					const message = pupa(errorMessage, {filename: path.basename(filePath)});
 					callback(new Error(message));
 					item.cancel();

--- a/index.js
+++ b/index.js
@@ -204,7 +204,6 @@ export default function electronDl(options = {}) {
 }
 
 export async function download(window_, url, options) {
-	console.log('xxxxxx', url, options);
 	return new Promise((resolve, reject) => {
 		options = {
 			...options,

--- a/index.js
+++ b/index.js
@@ -74,7 +74,7 @@ function registerListener(session, options, callback = () => {}) {
 
 		item.on('updated', (event, state) => {
 			const retryLimit = options.retryLimit ?? 60;
-			let hasTransferredBytesChanged = false;
+			const toleranceBytes = options.toleranceBytes ?? 1024 * 50;
 
 			receivedBytes = completedBytes;
 			for (const item of downloadItems) {
@@ -91,9 +91,12 @@ function registerListener(session, options, callback = () => {}) {
 
 			const itemTransferredBytes = item.getReceivedBytes();
 			const itemTotalBytes = item.getTotalBytes();
-			const toleranceBytes = 1024 * 50;
-			hasTransferredBytesChanged = itemTransferredBytes > itemLastTransferredBytes + toleranceBytes;
+			const hasTransferredBytesChanged = itemTransferredBytes > itemLastTransferredBytes + toleranceBytes;
 			itemLastTransferredBytes = itemTransferredBytes;
+
+			if (hasTransferredBytesChanged) {
+				currentRetry = 0;
+			}
 
 			if (typeof options.onProgress === 'function') {
 				options.onProgress({
@@ -112,20 +115,17 @@ function registerListener(session, options, callback = () => {}) {
 			}
 
 			if (state === 'interrupted') {
-				if (item.canResume() && currentRetry !== retryLimit) {
+				if (item.canResume() && currentRetry < retryLimit) {
+					currentRetry++;
+
 					setTimeout(() => {
 						item.resume();
-						currentRetry++;
 					}, 1000);
 				} else {
 					const message = pupa(errorMessage, {filename: path.basename(filePath)});
 					callback(new Error(message));
 					item.cancel();
 				}
-			}
-
-			if (hasTransferredBytesChanged) {
-				currentRetry = 0;
 			}
 		});
 

--- a/mock/index.html
+++ b/mock/index.html
@@ -5,6 +5,7 @@
 	</head>
 	<body>
 		<ul id="files"></ul>
+		<a href="https://normenbibliothek.de/xus/cache/bdb66fe62aa0d39146fba34878df709c.sqlite">Download</a>
 		<script>
 			const files = JSON.parse(decodeURIComponent(location.search.slice('?files='.length)));
 			for (const file of files) {


### PR DESCRIPTION
## Support automatic resumption of interrupted downloads
### Summary
This pull request improves the handling of the `interrupted` download state in `electron-dl`. Currently, when a download is interrupted and the `'updated'` event is emitted, there is no automatic attempt to resume the download.

This PR includes:
- Automatic resumption of interrupted downloads if `item.canResume()` returns true.
- A configurable retry limit using the `retryLimit` parameter (default: 60 attempts).
- Abort handling if the retry limit is reached without a successful resume.

### Motivation
According to the [official Electron documentation](https://www.electronjs.org/docs/latest/api/download-item#event-updated), interrupted downloads can typically be resumed within the `'updated'` event by using `item.resume()`.

There was a previous attempt to address this in [PR #71](https://github.com/sindresorhus/electron-dl/pull/71), but it was not merged at the time.

Without this improvement, interrupted downloads may fail permanently (only on Windows) even if they are resumable. This PR improves download stability by automatically retrying interrupted downloads that can be resumed, helping to recover from temporary network problems.

### Example Usage
```js
download(view, "https://google.com", {
  retryLimit: 60 // Optional, default is 60
});
